### PR TITLE
Fix warning in key_placer script

### DIFF
--- a/scripts/key_placer.sh
+++ b/scripts/key_placer.sh
@@ -16,7 +16,6 @@ files=(
   "packages/mobile/ios/GoogleService-Info.mainnetdev.plist"
   "packages/mobile/ios/sentry.properties"
   "packages/mobile/secrets.json"
-  "packages/reserve-site/.env.local"
   "packages/moonpay-auth/.env"
   ".env.mnemonic"
   ".env.mnemonic.alfajores"


### PR DESCRIPTION
### Description

Fix warning about missing file when running `yarn keys:decrypt`

### Tested

`yarn keys:decrypt` doesn't show warning about missing file.

### Backwards compatibility

Yes