### PR TITLE
Throw error when handling unknown transaction types

### DIFF
--- a/packages/blockchain-api/src/blockscout.ts
+++ b/packages/blockchain-api/src/blockscout.ts
@@ -169,9 +169,14 @@ export class BlockscoutAPI extends RESTDataSource {
 
     const aggregatedTransactions = TransactionAggregator.aggregate(classifiedTransactions)
 
-    const events: any[] = aggregatedTransactions.map(({ transaction, type }) =>
-      type.getEvent(transaction)
-    )
+    const events: any[] = aggregatedTransactions.map(({ transaction, type }) => {
+      try {
+        return type.getEvent(transaction)
+      } catch (e) {
+        console.error('Could not map to an event', JSON.stringify(transaction))
+        console.error(e)
+      }
+    })
 
     console.info(
       `[Celo] getTokenTransactions address=${args.address} token=${token} localCurrencyCode=${args.localCurrencyCode}} rawTransactionCount=${rawTransactions.length} eventCount=${events.length}`

--- a/packages/blockchain-api/src/events/Any.ts
+++ b/packages/blockchain-api/src/events/Any.ts
@@ -7,7 +7,7 @@ export class Any extends TransactionType {
   }
 
   getEvent(transaction: Transaction) {
-    return
+    throw new Error('Unknown transaction type')
   }
 
   isAggregatable(): boolean {

--- a/packages/blockchain-api/src/transaction/TransactionAggregator.ts
+++ b/packages/blockchain-api/src/transaction/TransactionAggregator.ts
@@ -22,7 +22,7 @@ export class TransactionAggregator {
     currentIndex: number,
     array: ClassifiedTransaction[]
   ): ClassifiedTransaction[] {
-    if (currentTransaction.type.isAggregatable()) {
+    if (currentTransaction.type.isAggregatable() && accumulator.length > 0) {
       const transactionFees = currentTransaction.type.getFees(currentTransaction.transaction)
 
       transactionFees.forEach((fee) => accumulator[accumulator.length - 1].transaction.addFee(fee))


### PR DESCRIPTION
### Description

When a transaction can't be properly classified based on the list of transfers, it should be reported rather than silently ignored. Fixes celo-org/celo-monorepo#6997.

### Tested

Yes.

### Backwards compatibility

Yes. The invalid transaction is still being ignored, this change improves logging and visibility on data issues.