### PR TITLE
Small UI changes to CELO deposit review screen

### DIFF
--- a/packages/mobile/locales/en-US/walletFlow5.json
+++ b/packages/mobile/locales/en-US/walletFlow5.json
@@ -112,6 +112,7 @@
   "transactionHeaderWithdrewCelo": "CELO Withdrawal",
   "transactionHeaderEscrowSent": "Escrow Payment Sent",
   "transactionHeaderReceived": "Payment Received",
+  "transactionHeaderCeloDeposit": "Deposit Received",
   "transactionHeaderCeloReward": "Reward Received",
   "transactionHeaderEscrowReceived": "Escrow Payment Received",
   "feedSectionHeaderRecent": "Recent"

--- a/packages/mobile/locales/es-419/walletFlow5.json
+++ b/packages/mobile/locales/es-419/walletFlow5.json
@@ -112,6 +112,7 @@
   "transactionHeaderWithdrewCelo": "Retiro de CELO",
   "transactionHeaderEscrowSent": "Escrow Pago Enviado",
   "transactionHeaderReceived": "Pago Recibido",
+  "transactionHeaderCeloDeposit": "Depósito Recibido",
   "transactionHeaderCeloReward": "Recompensa Recibida",
   "transactionHeaderEscrowReceived": "Escrow Pago Recibido",
   "feedSectionHeaderRecent": "Recientes"

--- a/packages/mobile/locales/pt-BR/walletFlow5.json
+++ b/packages/mobile/locales/pt-BR/walletFlow5.json
@@ -112,6 +112,7 @@
   "transactionHeaderWithdrewCelo": "Saque CELO",
   "transactionHeaderEscrowSent": "Pagamento de caução enviado",
   "transactionHeaderReceived": "Pagamento recebido",
+  "transactionHeaderCeloDeposit": "Depósito Recebido",
   "transactionHeaderCeloReward": "Recompensa recebida",
   "transactionHeaderEscrowReceived": "Pagamento de caução recebido",
   "feedSectionHeaderRecent": "Recente"

--- a/packages/mobile/src/app/actions.ts
+++ b/packages/mobile/src/app/actions.ts
@@ -1,3 +1,4 @@
+import { RemoteFeatureFlags } from 'src/app/saga'
 import i18n from 'src/i18n'
 import { Screens } from 'src/navigator/Screens'
 import Logger from 'src/utils/Logger'
@@ -26,8 +27,7 @@ export enum Actions {
   SET_SESSION_ID = 'SET_SESSION_ID',
   OPEN_URL = 'APP/OPEN_URL',
   MIN_APP_VERSION_DETERMINED = 'APP/MIN_APP_VERSION_DETERMINED',
-  SET_PONTO_FEATURE_FLAG = 'APP/SET_PONTO_FEATURE_FLAG',
-  SET_KOTANI_FEATURE_FLAG = 'APP/SET_KOTANI_FEATURE_FLAG',
+  UPDATE_FEATURE_FLAGS = 'APP/UPDATE_FEATURE_FLAGS',
   TOGGLE_INVITE_MODAL = 'APP/TOGGLE_INVITE_MODAL',
   ACTIVE_SCREEN_CHANGED = 'APP/ACTIVE_SCREEN_CHANGED',
 }
@@ -107,14 +107,9 @@ interface MinAppVersionDeterminedAction {
   minVersion: string | null
 }
 
-interface PontoFeatureFlagSetAction {
-  type: Actions.SET_PONTO_FEATURE_FLAG
-  enabled: boolean
-}
-
-interface KotaniFeatureFlagSetAction {
-  type: Actions.SET_KOTANI_FEATURE_FLAG
-  enabled: boolean
+interface UpdateFeatureFlagsAction {
+  type: Actions.UPDATE_FEATURE_FLAGS
+  flags: RemoteFeatureFlags
 }
 
 export type ActionTypes =
@@ -131,8 +126,7 @@ export type ActionTypes =
   | SetSessionId
   | OpenUrlAction
   | MinAppVersionDeterminedAction
-  | PontoFeatureFlagSetAction
-  | KotaniFeatureFlagSetAction
+  | UpdateFeatureFlagsAction
   | InviteModalAction
   | ActiveScreenChangedAction
 
@@ -215,14 +209,9 @@ export const minAppVersionDetermined = (
   minVersion,
 })
 
-export const setPontoFeatureFlag = (enabled: boolean) => ({
-  type: Actions.SET_PONTO_FEATURE_FLAG,
-  enabled,
-})
-
-export const setKotaniFeatureFlag = (enabled: boolean) => ({
-  type: Actions.SET_KOTANI_FEATURE_FLAG,
-  enabled,
+export const updateFeatureFlags = (flags: RemoteFeatureFlags): UpdateFeatureFlagsAction => ({
+  type: Actions.UPDATE_FEATURE_FLAGS,
+  flags,
 })
 
 export const toggleInviteModal = (inviteModalVisible: boolean): InviteModalAction => ({

--- a/packages/mobile/src/app/reducers.ts
+++ b/packages/mobile/src/app/reducers.ts
@@ -18,6 +18,7 @@ export interface State {
   minVersion: string | null
   pontoEnabled: boolean
   kotaniEnabled: boolean
+  celoEducationUri: string | null
   inviteModalVisible: boolean
   activeScreen: Screens
 }
@@ -36,6 +37,7 @@ const initialState = {
   minVersion: null,
   pontoEnabled: false,
   kotaniEnabled: false,
+  celoEducationUri: null,
   inviteModalVisible: false,
   activeScreen: Screens.Main,
 }
@@ -132,15 +134,12 @@ export const appReducer = (
         ...state,
         minVersion: action.minVersion,
       }
-    case Actions.SET_PONTO_FEATURE_FLAG:
+    case Actions.UPDATE_FEATURE_FLAGS:
       return {
         ...state,
-        pontoEnabled: action.enabled,
-      }
-    case Actions.SET_KOTANI_FEATURE_FLAG:
-      return {
-        ...state,
-        kotaniEnabled: action.enabled,
+        pontoEnabled: action.flags.pontoEnabled,
+        kotaniEnabled: action.flags.kotaniEnabled,
+        celoEducationUri: action.flags.celoEducationUri,
       }
     case Actions.TOGGLE_INVITE_MODAL:
       return {

--- a/packages/mobile/src/app/saga.ts
+++ b/packages/mobile/src/app/saga.ts
@@ -23,9 +23,8 @@ import {
   OpenUrlAction,
   SetAppState,
   setAppState,
-  setKotaniFeatureFlag,
   setLanguage,
-  setPontoFeatureFlag,
+  updateFeatureFlags,
 } from 'src/app/actions'
 import { currentLanguageSelector } from 'src/app/reducers'
 import { getLastTimeBackgrounded, getRequirePinOnAppOpen } from 'src/app/selectors'
@@ -88,9 +87,10 @@ export function* appVersionSaga() {
   }
 }
 
-interface RemoteFeatureFlags {
+export interface RemoteFeatureFlags {
   kotaniEnabled: boolean
   pontoEnabled: boolean
+  celoEducationUri: string | null
 }
 
 export function* appRemoteFeatureFlagSaga() {
@@ -101,12 +101,8 @@ export function* appRemoteFeatureFlagSaga() {
   try {
     while (true) {
       const flags: RemoteFeatureFlags = yield take(remoteFeatureFlagChannel)
-      Logger.info(
-        TAG,
-        `Updated flags to ponto: ${flags.pontoEnabled} and kotani: ${flags.kotaniEnabled}`
-      )
-      yield put(setPontoFeatureFlag(flags.pontoEnabled))
-      yield put(setKotaniFeatureFlag(flags.kotaniEnabled))
+      Logger.info(TAG, 'Updated feature flags', JSON.stringify(flags))
+      yield put(updateFeatureFlags(flags))
     }
   } catch (error) {
     Logger.error(`${TAG}@appRemoteFeatureFlagSaga`, error)

--- a/packages/mobile/src/firebase/firebase.ts
+++ b/packages/mobile/src/firebase/firebase.ts
@@ -222,6 +222,7 @@ export function appRemoteFeatureFlagChannel() {
       emit({
         kotaniEnabled: flags?.kotaniEnabled || false,
         pontoEnabled: flags?.pontoEnabled || false,
+        celoEducationUri: flags?.celoEducationUri ?? null,
       })
     }
     const cancel = () => {

--- a/packages/mobile/src/firebase/notifications.test.ts
+++ b/packages/mobile/src/firebase/notifications.test.ts
@@ -126,7 +126,6 @@ describe(handleNotification, () => {
           type: 'RECEIVED',
         },
         reviewProps: {
-          header: 'walletFlow5:transactionHeaderReceived',
           timestamp: 1,
           type: 'RECEIVED',
         },

--- a/packages/mobile/src/firebase/notifications.ts
+++ b/packages/mobile/src/firebase/notifications.ts
@@ -5,7 +5,7 @@ import { showMessage } from 'src/alert/actions'
 import { TokenTransactionType } from 'src/apollo/types'
 import { openUrl } from 'src/app/actions'
 import { CURRENCIES, resolveCurrency } from 'src/geth/consts'
-import { addressToDisplayNameSelector, addressToE164NumberSelector } from 'src/identity/reducer'
+import { addressToE164NumberSelector } from 'src/identity/reducer'
 import {
   NotificationReceiveState,
   NotificationTypes,
@@ -61,7 +61,6 @@ function* handlePaymentReceived(
   if (notificationState !== NotificationReceiveState.APP_ALREADY_OPEN) {
     const recipientCache = yield select(recipientCacheSelector)
     const addressToE164Number = yield select(addressToE164NumberSelector)
-    const addressToDisplayName = yield select(addressToDisplayNameSelector)
     const address = transferNotification.sender.toLowerCase()
     const currency = resolveCurrency(transferNotification.currency)
 
@@ -77,8 +76,7 @@ function* handlePaymentReceived(
         comment: transferNotification.comment,
         recipient: getRecipientFromAddress(address, addressToE164Number, recipientCache),
         type: TokenTransactionType.Received,
-      },
-      addressToDisplayName
+      }
     )
   }
 }

--- a/packages/mobile/src/navigator/Navigator.tsx
+++ b/packages/mobile/src/navigator/Navigator.tsx
@@ -21,7 +21,6 @@ import BackupComplete from 'src/backup/BackupComplete'
 import BackupForceScreen from 'src/backup/BackupForceScreen'
 import BackupPhrase, { navOptionsForBackupPhrase } from 'src/backup/BackupPhrase'
 import BackupQuiz, { navOptionsForQuiz } from 'src/backup/BackupQuiz'
-import BackButton from 'src/components/BackButton'
 import CancelButton from 'src/components/CancelButton'
 import ConsumerIncentivesHomeScreen from 'src/consumerIncentives/ConsumerIncentivesHomeScreen'
 import DappKitAccountScreen from 'src/dappkit/DappKitAccountScreen'
@@ -101,7 +100,6 @@ import ValidateRecipientIntro, {
 import SetClock from 'src/set-clock/SetClock'
 import TransactionReview from 'src/transactions/TransactionReview'
 import Logger from 'src/utils/Logger'
-import { getDatetimeDisplayString } from 'src/utils/time'
 import { ExtractProps } from 'src/utils/typescript'
 import VerificationEducationScreen from 'src/verify/VerificationEducationScreen'
 import VerificationInputScreen from 'src/verify/VerificationInputScreen'
@@ -478,29 +476,13 @@ const settingsScreens = (Navigator: typeof Stack) => (
   </>
 )
 
-const transactionReviewOptions = ({
-  route,
-}: {
-  route: RouteProp<StackParamList, Screens.TransactionReview>
-}) => {
-  const { header, timestamp } = route.params?.reviewProps
-  const dateTimeStatus = getDatetimeDisplayString(timestamp, i18n)
-  return {
-    ...emptyHeader,
-    headerLeft: () => (
-      <BackButton color={colors.dark} eventName={CeloExchangeEvents.celo_transaction_back} />
-    ),
-    headerTitle: () => <HeaderTitleWithSubtitle title={header} subTitle={dateTimeStatus} />,
-  }
-}
-
 const generalScreens = (Navigator: typeof Stack) => (
   <>
     <Navigator.Screen name={Screens.SetClock} component={SetClock} />
     <Navigator.Screen
       name={Screens.TransactionReview}
       component={TransactionReview}
-      options={transactionReviewOptions}
+      options={TransactionReview.navOptions}
     />
   </>
 )

--- a/packages/mobile/src/transactions/CeloTransferFeedItem.tsx
+++ b/packages/mobile/src/transactions/CeloTransferFeedItem.tsx
@@ -32,18 +32,13 @@ export function CeloTransferFeedItem(props: Props) {
   const onPress = () => {
     ValoraAnalytics.track(CeloExchangeEvents.celo_transaction_select)
 
-    navigateToPaymentTransferReview(
+    navigateToPaymentTransferReview(type, timestamp, {
+      address,
+      comment,
+      amount,
       type,
-      timestamp,
-      {
-        address,
-        comment,
-        amount,
-        type,
-        // fee TODO: add fee here.
-      },
-      addressToDisplayName
-    )
+      // fee TODO: add fee here.
+    })
   }
 
   const dateTimeFormatted = getDatetimeDisplayString(timestamp, i18n)

--- a/packages/mobile/src/transactions/TransactionReview.test.tsx
+++ b/packages/mobile/src/transactions/TransactionReview.test.tsx
@@ -35,7 +35,6 @@ describe('TransactionReview', () => {
       reviewProps: {
         timestamp: Date.now(),
         type: TokenTransactionType.Sent,
-        header: 'Payment Send',
       },
     })
 

--- a/packages/mobile/src/transactions/TransactionReview.tsx
+++ b/packages/mobile/src/transactions/TransactionReview.tsx
@@ -1,17 +1,23 @@
 import { StackScreenProps } from '@react-navigation/stack'
 import * as React from 'react'
+import { useLayoutEffect } from 'react'
 import { connect } from 'react-redux'
 import { TokenTransactionType } from 'src/apollo/types'
 import ExchangeConfirmationCard, {
   ExchangeConfirmationCardProps,
 } from 'src/exchange/ExchangeConfirmationCard'
-import { SecureSendPhoneNumberMapping } from 'src/identity/reducer'
+import i18n from 'src/i18n'
+import { addressToDisplayNameSelector, SecureSendPhoneNumberMapping } from 'src/identity/reducer'
+import { HeaderTitleWithSubtitle, headerWithBackButton } from 'src/navigator/Headers'
 import { Screens } from 'src/navigator/Screens'
 import { StackParamList } from 'src/navigator/types'
 import { RootState } from 'src/redux/reducers'
+import useSelector from 'src/redux/useSelector'
 import TransferConfirmationCard, {
   TransferConfirmationCardProps,
 } from 'src/transactions/TransferConfirmationCard'
+import { exchangeReviewHeader, transferReviewHeader } from 'src/transactions/utils'
+import { getDatetimeDisplayString } from 'src/utils/time'
 
 interface StateProps {
   addressHasChanged: boolean
@@ -19,7 +25,6 @@ interface StateProps {
 export interface ReviewProps {
   type: TokenTransactionType
   timestamp: number
-  header: string
 }
 
 type OwnProps = StackScreenProps<StackParamList, Screens.TransactionReview>
@@ -59,8 +64,29 @@ const mapStateToProps = (state: RootState, ownProps: OwnProps): StateProps => {
   return { addressHasChanged }
 }
 
-function TransactionReview({ route, addressHasChanged }: Props) {
-  const { confirmationProps } = route.params
+function isExchange(
+  confirmationProps: ExchangeConfirmationCardProps | TransferConfirmationCardProps
+): confirmationProps is ExchangeConfirmationCardProps {
+  return (confirmationProps as ExchangeConfirmationCardProps).makerAmount !== undefined
+}
+
+function TransactionReview({ navigation, route, addressHasChanged }: Props) {
+  const {
+    reviewProps: { type, timestamp },
+    confirmationProps,
+  } = route.params
+  const addressToDisplayName = useSelector(addressToDisplayNameSelector)
+
+  useLayoutEffect(() => {
+    const dateTimeStatus = getDatetimeDisplayString(timestamp, i18n)
+    const header = isExchange(confirmationProps)
+      ? exchangeReviewHeader(confirmationProps)
+      : transferReviewHeader(type, confirmationProps, addressToDisplayName)
+
+    navigation.setOptions({
+      headerTitle: () => <HeaderTitleWithSubtitle title={header} subTitle={dateTimeStatus} />,
+    })
+  }, [type, confirmationProps, addressToDisplayName])
 
   if (isTransferConfirmationCardProps(confirmationProps)) {
     const props = { ...confirmationProps, addressHasChanged }
@@ -69,5 +95,7 @@ function TransactionReview({ route, addressHasChanged }: Props) {
 
   return <ExchangeConfirmationCard {...confirmationProps} />
 }
+
+TransactionReview.navOptions = headerWithBackButton
 
 export default connect<StateProps, {}, OwnProps, RootState>(mapStateToProps, {})(TransactionReview)

--- a/packages/mobile/src/transactions/TransactionReview.tsx
+++ b/packages/mobile/src/transactions/TransactionReview.tsx
@@ -1,6 +1,5 @@
 import { StackScreenProps } from '@react-navigation/stack'
-import * as React from 'react'
-import { useLayoutEffect } from 'react'
+import React, { useLayoutEffect } from 'react'
 import { connect } from 'react-redux'
 import { TokenTransactionType } from 'src/apollo/types'
 import ExchangeConfirmationCard, {

--- a/packages/mobile/src/transactions/TransferConfirmationCard.tsx
+++ b/packages/mobile/src/transactions/TransferConfirmationCard.tsx
@@ -22,6 +22,7 @@ import { getInvitationVerificationFeeInDollars } from 'src/invite/saga'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { getRecipientThumbnail, Recipient } from 'src/recipients/recipient'
+import useTypedSelector from 'src/redux/useSelector'
 import BottomText from 'src/transactions/BottomText'
 import CommentSection from 'src/transactions/CommentSection'
 import TransferAvatars from 'src/transactions/TransferAvatars'
@@ -206,7 +207,14 @@ function PaymentSentContent({
 }
 
 function PaymentReceivedContent({ address, recipient, e164PhoneNumber, amount, comment }: Props) {
+  const { t } = useTranslation(Namespaces.sendFlow7)
   const totalAmount = amount
+  const isCeloTx = amount.currencyCode === CURRENCIES[CURRENCY_ENUM.GOLD].code
+  const celoEducationUri = useTypedSelector((state) => state.app.celoEducationUri)
+
+  const openLearnMore = () => {
+    navigate(Screens.WebViewScreen, { uri: celoEducationUri! })
+  }
 
   return (
     <>
@@ -218,6 +226,11 @@ function PaymentReceivedContent({ address, recipient, e164PhoneNumber, amount, c
         avatar={<TransferAvatars type="received" address={address} recipient={recipient} />}
       />
       <CommentSection comment={comment} />
+      {isCeloTx && celoEducationUri && (
+        <TouchableOpacity onPress={openLearnMore} testID={'celoTxReceived/learnMore'}>
+          <Text style={styles.learnMore}>{t('learnMore')}</Text>
+        </TouchableOpacity>
+      )}
       <HorizontalLine />
       <TotalLineItem amount={totalAmount} />
     </>

--- a/packages/mobile/src/transactions/TransferFeedItem.tsx
+++ b/packages/mobile/src/transactions/TransferFeedItem.tsx
@@ -6,11 +6,7 @@ import { HomeEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import { TokenTransactionType, TransferItemFragment } from 'src/apollo/types'
 import { Namespaces } from 'src/i18n'
-import {
-  addressToDisplayNameSelector,
-  AddressToDisplayNameType,
-  AddressToE164NumberType,
-} from 'src/identity/reducer'
+import { addressToDisplayNameSelector, AddressToE164NumberType } from 'src/identity/reducer'
 import { InviteDetails } from 'src/invite/actions'
 import { getRecipientFromAddress, NumberToRecipient } from 'src/recipients/recipient'
 import { navigateToPaymentTransferReview } from 'src/transactions/actions'
@@ -41,8 +37,7 @@ function navigateToTransactionReview({
   amount,
   addressToE164Number,
   recipientCache,
-  addressToDisplayName,
-}: Props & { addressToDisplayName: AddressToDisplayNameType }) {
+}: Props) {
   // TODO: remove this when verification reward drilldown is supported
   if (type === TokenTransactionType.VerificationReward) {
     return
@@ -51,20 +46,15 @@ function navigateToTransactionReview({
   const recipient = getRecipientFromAddress(address, addressToE164Number, recipientCache)
   const e164PhoneNumber = addressToE164Number[address] || undefined
 
-  navigateToPaymentTransferReview(
+  navigateToPaymentTransferReview(type, timestamp, {
+    address,
+    comment: getDecryptedTransferFeedComment(comment, commentKey, type),
+    amount,
+    recipient,
     type,
-    timestamp,
-    {
-      address,
-      comment: getDecryptedTransferFeedComment(comment, commentKey, type),
-      amount,
-      recipient,
-      type,
-      e164PhoneNumber,
-      // fee TODO: add fee here.
-    },
-    addressToDisplayName
-  )
+    e164PhoneNumber,
+    // fee TODO: add fee here.
+  })
 }
 
 export function TransferFeedItem(props: Props) {
@@ -72,7 +62,7 @@ export function TransferFeedItem(props: Props) {
   const addressToDisplayName = useSelector(addressToDisplayNameSelector)
 
   const onPress = () => {
-    navigateToTransactionReview({ ...props, addressToDisplayName })
+    navigateToTransactionReview(props)
     ValoraAnalytics.track(HomeEvents.transaction_feed_item_select)
   }
 

--- a/packages/mobile/src/transactions/actions.ts
+++ b/packages/mobile/src/transactions/actions.ts
@@ -1,9 +1,6 @@
 import { SendOrigin } from 'src/analytics/types'
 import { TokenTransactionType, TransactionFeedFragment } from 'src/apollo/types'
 import { ExchangeConfirmationCardProps } from 'src/exchange/ExchangeConfirmationCard'
-import { CURRENCIES, CURRENCY_ENUM } from 'src/geth/consts'
-import i18n from 'src/i18n'
-import { AddressToDisplayNameType } from 'src/identity/reducer'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { NumberToRecipient } from 'src/recipients/recipient'
@@ -123,53 +120,12 @@ export const newTransactionsInFeed = (
 export const navigateToPaymentTransferReview = (
   type: TokenTransactionType,
   timestamp: number,
-  confirmationProps: TransferConfirmationCardProps,
-  addressToDisplayName: AddressToDisplayNameType
+  confirmationProps: TransferConfirmationCardProps
 ) => {
-  let headerText = ''
-  switch (type) {
-    case TokenTransactionType.Sent:
-      const isCeloWithdrawal =
-        confirmationProps.amount.currencyCode === CURRENCIES[CURRENCY_ENUM.GOLD].code
-      headerText = i18n.t(
-        isCeloWithdrawal
-          ? 'walletFlow5:transactionHeaderWithdrewCelo'
-          : 'walletFlow5:transactionHeaderSent'
-      )
-      break
-    case TokenTransactionType.EscrowSent:
-      headerText = i18n.t('walletFlow5:transactionHeaderEscrowSent')
-      break
-    case TokenTransactionType.Received:
-      headerText = addressToDisplayName[confirmationProps.address || '']?.isCeloRewardSender
-        ? i18n.t('walletFlow5:transactionHeaderCeloReward')
-        : i18n.t('walletFlow5:transactionHeaderReceived')
-      break
-    case TokenTransactionType.EscrowReceived:
-      headerText = i18n.t('walletFlow5:transactionHeaderEscrowReceived')
-      break
-    case TokenTransactionType.VerificationFee:
-      headerText = i18n.t('walletFlow5:transactionHeaderVerificationFee')
-      break
-    case TokenTransactionType.Faucet:
-      headerText = i18n.t('walletFlow5:transactionHeaderFaucet')
-      break
-    case TokenTransactionType.InviteSent:
-      headerText = i18n.t('walletFlow5:transactionHeaderInviteSent')
-      break
-    case TokenTransactionType.InviteReceived:
-      headerText = i18n.t('walletFlow5:transactionHeaderInviteReceived')
-      break
-    case TokenTransactionType.NetworkFee:
-      headerText = i18n.t('walletFlow5:transactionHeaderNetworkFee')
-      break
-  }
-
   navigate(Screens.TransactionReview, {
     reviewProps: {
       type,
       timestamp,
-      header: headerText,
     },
     confirmationProps,
   })
@@ -179,13 +135,10 @@ export const navigateToExchangeReview = (
   timestamp: number,
   confirmationProps: ExchangeConfirmationCardProps
 ) => {
-  const { makerAmount } = confirmationProps
-  const isSold = makerAmount.currencyCode === CURRENCIES[CURRENCY_ENUM.GOLD].code
   navigate(Screens.TransactionReview, {
     reviewProps: {
       type: TokenTransactionType.Exchange,
       timestamp,
-      header: isSold ? i18n.t('exchangeFlow9:soldGold') : i18n.t('exchangeFlow9:purchasedGold'),
     },
     confirmationProps,
   })

--- a/packages/mobile/src/transactions/utils.ts
+++ b/packages/mobile/src/transactions/utils.ts
@@ -1,5 +1,10 @@
+import { TokenTransactionType } from 'src/apollo/types'
+import { ExchangeConfirmationCardProps } from 'src/exchange/ExchangeConfirmationCard'
+import { CURRENCIES, CURRENCY_ENUM } from 'src/geth/consts'
 import i18n from 'src/i18n'
+import { AddressToDisplayNameType } from 'src/identity/reducer'
 import { FeedItem } from 'src/transactions/TransactionFeed'
+import { TransferConfirmationCardProps } from 'src/transactions/TransferConfirmationCard'
 import { formatFeedSectionTitle, timeDeltaInDays } from 'src/utils/time'
 
 // Groupings:
@@ -36,4 +41,57 @@ export const groupFeedItemsInSections = (feedItems: FeedItem[]) => {
       title: key,
       data: value.data,
     }))
+}
+
+export const exchangeReviewHeader = (confirmationProps: ExchangeConfirmationCardProps) => {
+  const { makerAmount } = confirmationProps
+  const isSold = makerAmount.currencyCode === CURRENCIES[CURRENCY_ENUM.GOLD].code
+  return isSold ? i18n.t('exchangeFlow9:soldGold') : i18n.t('exchangeFlow9:purchasedGold')
+}
+
+export const transferReviewHeader = (
+  type: TokenTransactionType,
+  confirmationProps: TransferConfirmationCardProps,
+  addressToDisplayName: AddressToDisplayNameType
+) => {
+  let headerText = ''
+  const isCeloTx = confirmationProps.amount.currencyCode === CURRENCIES[CURRENCY_ENUM.GOLD].code
+  switch (type) {
+    case TokenTransactionType.Sent:
+      headerText = i18n.t(
+        isCeloTx ? 'walletFlow5:transactionHeaderWithdrewCelo' : 'walletFlow5:transactionHeaderSent'
+      )
+      break
+    case TokenTransactionType.EscrowSent:
+      headerText = i18n.t('walletFlow5:transactionHeaderEscrowSent')
+      break
+    case TokenTransactionType.Received:
+      if (addressToDisplayName[confirmationProps.address || '']?.isCeloRewardSender) {
+        headerText = i18n.t('walletFlow5:transactionHeaderCeloReward')
+      }
+      headerText = isCeloTx
+        ? i18n.t('walletFlow5:transactionHeaderCeloDeposit')
+        : i18n.t('walletFlow5:transactionHeaderReceived')
+      break
+    case TokenTransactionType.EscrowReceived:
+      headerText = i18n.t('walletFlow5:transactionHeaderEscrowReceived')
+      break
+    case TokenTransactionType.VerificationFee:
+      headerText = i18n.t('walletFlow5:transactionHeaderVerificationFee')
+      break
+    case TokenTransactionType.Faucet:
+      headerText = i18n.t('walletFlow5:transactionHeaderFaucet')
+      break
+    case TokenTransactionType.InviteSent:
+      headerText = i18n.t('walletFlow5:transactionHeaderInviteSent')
+      break
+    case TokenTransactionType.InviteReceived:
+      headerText = i18n.t('walletFlow5:transactionHeaderInviteReceived')
+      break
+    case TokenTransactionType.NetworkFee:
+      headerText = i18n.t('walletFlow5:transactionHeaderNetworkFee')
+      break
+  }
+
+  return headerText
 }

--- a/packages/mobile/test/schemas.ts
+++ b/packages/mobile/test/schemas.ts
@@ -472,6 +472,7 @@ export const v7Schema = {
   app: {
     ...v6Schema.app,
     activeScreen: '',
+    celoEducationUri: null,
   },
   account: {
     ...v6Schema.account,


### PR DESCRIPTION
### Description

As part of the Coinbase advanced earn campaign they'll be sending CELO to user's addresses, so we're making some tweaks to the review screen and adding an educational screen to educate them on what we're building

The changes wanted (and future oens) are documented on this doc: https://docs.google.com/document/d/1GYSiFKtwMguQxZtoZvOgJfdI7XyX--gFwdm5pmSY4T8/edit?ts=601b43e1#

<img width="362" alt="Screen Shot 2021-02-16 at 18 41 35" src="https://user-images.githubusercontent.com/6062888/108125537-58f0bd00-7087-11eb-9e5b-36aebd774fce.png">


### Other changes

- Refactored the way feature flags are fetched from Firebase to make it easier to add new ones.
- The header of the review screen was being calculated and sent as a prop to the review screen, which made little sense. Moved it to the review screen where it belongs.

### Tested

Manually

### Related issues

- Fixes #6

### Backwards compatibility

N/A