### PR TITLE
Fix CICO provider redirect bug

### DIFF
--- a/packages/mobile/src/fiatExchanges/RampScreen.tsx
+++ b/packages/mobile/src/fiatExchanges/RampScreen.tsx
@@ -53,7 +53,7 @@ function RampScreen({ route }: Props) {
       &hostLogoUrl=${VALORA_LOGO_URL}
       &fiatCurrency=${currencyCode}
       &fiatValue=${localAmount || minTxAmount}
-      &finalUrl=${encodeURI(CASH_IN_SUCCESS_DEEPLINK)}
+      &finalUrl=${encodeURIComponent(CASH_IN_SUCCESS_DEEPLINK)}
     `.replace(/\s+/g, '')
 
   return <InAppBrowser uri={uri} onCancel={navigateBack} />

--- a/packages/moonpay-auth/src/index.ts
+++ b/packages/moonpay-auth/src/index.ts
@@ -22,7 +22,7 @@ export const signMoonpayStaging = functions.https.onRequest((request, response) 
       &walletAddress=${request.body.address}
       &baseCurrencyCode=${fiatCurrency}
       &baseCurrencyAmount=${fiatAmount}
-      &redirectURL=${encodeURI(CASH_IN_SUCCESS_DEEPLINK)}
+      &redirectURL=${encodeURIComponent(CASH_IN_SUCCESS_DEEPLINK)}
       `.replace(/\s+/g, '')
 
   console.log(`Requested signature for: ${url}`)
@@ -53,7 +53,7 @@ export const signMoonpayProd = functions.https.onRequest((request, response) => 
       &walletAddress=${request.body.address}
       &baseCurrencyCode=${fiatCurrency}
       &baseCurrencyAmount=${fiatAmount}
-      &redirectURL=${encodeURI(CASH_IN_SUCCESS_DEEPLINK)}
+      &redirectURL=${encodeURIComponent(CASH_IN_SUCCESS_DEEPLINK)}
       `.replace(/\s+/g, '')
 
   console.log(`Requested signature for: ${url}`)


### PR DESCRIPTION
### Description
We needed to use `encodeURIComponent` instead of `encodeURI` to properly encode our redirect links.

### Other changes
N/A

### Tested
Manually

### Related issues
N/A

### Backwards compatibility
Yes