### PR TITLE
Enable inlineRequire to improve app start performance

### DIFF
--- a/packages/mobile/metro.config.js
+++ b/packages/mobile/metro.config.js
@@ -17,6 +17,14 @@ const defaultSourceExts = require('metro-config/src/defaults/defaults').sourceEx
 const defaultAssetExts = require('metro-config/src/defaults/defaults').assetExts
 
 module.exports = {
+  transformer: {
+    getTransformOptions: async () => ({
+      transform: {
+        experimentalImportSupport: false,
+        inlineRequires: true,
+      },
+    }),
+  },
   resolver: {
     assetExts: [...defaultAssetExts, 'txt'],
     blacklistRE: blacklist(


### PR DESCRIPTION
### Description

From: https://reactnative.dev/docs/ram-bundles-inline-requires

> Inline requires delay the requiring of a module or file until that file is actually needed

The obvious question is how do we know if this is helping?

### Other changes

_Describe any minor or "drive-by" changes here._

### Tested

It would be good to setup performance tests for app start. I am thinking we could have an e2e test that just starts the app 20 times and presents statistics on: time taken, memory usage, etc

So far I am manually testing app open as well as adding logs to the top of the core modules to see if this actually works as intended.

### Related issues

- Fixes celo-monorepo/issues#5433

### Backwards compatibility

Yes