### PR TITLE
Add notification id to analytics event HomeEvents.notification_select

### DIFF
--- a/packages/mobile/src/analytics/Properties.tsx
+++ b/packages/mobile/src/analytics/Properties.tsx
@@ -80,6 +80,7 @@ interface HomeEventsProperties {
   [HomeEvents.notification_select]: {
     notificationType: NotificationBannerTypes
     selectedAction: NotificationBannerCTATypes
+    notificationId?: string
   }
   [HomeEvents.transaction_feed_item_select]: undefined
   [HomeEvents.transaction_feed_address_copy]: undefined

--- a/packages/mobile/src/home/NotificationBox.tsx
+++ b/packages/mobile/src/home/NotificationBox.tsx
@@ -244,6 +244,7 @@ export class NotificationBox extends React.Component<Props, State> {
               ValoraAnalytics.track(HomeEvents.notification_select, {
                 notificationType: NotificationBannerTypes.remote_notification,
                 selectedAction: NotificationBannerCTATypes.remote_notification_cta,
+                notificationId: id,
               })
               openUrl(notification.ctaUri, false, true)
             },
@@ -255,6 +256,7 @@ export class NotificationBox extends React.Component<Props, State> {
               ValoraAnalytics.track(HomeEvents.notification_select, {
                 notificationType: NotificationBannerTypes.remote_notification,
                 selectedAction: NotificationBannerCTATypes.decline,
+                notificationId: id,
               })
               this.props.dismissNotification(id)
             },


### PR DESCRIPTION
### Description

Adding this id to this event will allows us to know engagement with each individual notification. Right now we have only a generic 'remote_notification' type.

### Tested

Manually.

### Related issues

- Fixes #62

### Backwards compatibility

No, we won't be able to track clicks by individual notification in previous versions of the app.