### PR TITLE
Change the way cutoff for rewards is calculated

### DIFF
--- a/packages/mobile/src/consumerIncentives/ConsumerIncentivesHomeScreen.tsx
+++ b/packages/mobile/src/consumerIncentives/ConsumerIncentivesHomeScreen.tsx
@@ -31,7 +31,7 @@ import useSelector from 'src/redux/useSelector'
 import { stableTokenBalanceSelector } from 'src/stableToken/reducer'
 import { getContentForCurrentLang } from 'src/utils/contentTranslations'
 import Logger from 'src/utils/Logger'
-import { formatFeedDate } from 'src/utils/time'
+import { formatFeedDate, getNextMondayAt8pmUtc } from 'src/utils/time'
 
 const TAG = 'ConsumerIncentivesHomeScreen'
 
@@ -130,7 +130,7 @@ export default function ConsumerIncentivesHomeScreen(props: Props) {
                   ns={Namespaces.consumerIncentives}
                   tOptions={{
                     cUsdToAdd: amountToAdd,
-                    date: formatFeedDate(content.nextDistribution, i18n),
+                    date: formatFeedDate(getNextMondayAt8pmUtc(), i18n),
                     level: t('level', { level: nextLevel }),
                   }}
                 >

--- a/packages/mobile/src/utils/time.ts
+++ b/packages/mobile/src/utils/time.ts
@@ -3,6 +3,7 @@ const momentTimezone = require('moment-timezone')
 import differenceInYears from 'date-fns/esm/differenceInYears'
 import format from 'date-fns/esm/format'
 import getYear from 'date-fns/esm/getYear'
+import startOfWeek from 'date-fns/esm/startOfWeek'
 import { i18n as i18nType } from 'i18next'
 import locales from 'locales'
 import _ from 'lodash'
@@ -340,4 +341,13 @@ function quickFormat(timestamp: number, i18next: i18nType, formatRule: string) {
   return format(millisecondsSinceEpoch(timestamp), formatRule, {
     locale: locales[i18next?.language]?.dateFns ?? locales['en-US']?.dateFns,
   })
+}
+
+function toUtcDate(date: Date) {
+  return new Date(date.getTime() - date.getTimezoneOffset() * 60 * 1000)
+}
+
+export function getNextMondayAt8pmUtc() {
+  const mondayDate = startOfWeek(Date.now(), { weekStartsOn: 1 })
+  return toUtcDate(mondayDate).getTime() + 20 * ONE_HOUR_IN_MILLIS + 7 * ONE_DAY_IN_MILLIS
 }


### PR DESCRIPTION
### Description

In this version, we had added a `nextDistribution` field to Firebase. For some reason, it was under the `content` item, which made no sense and caused the app to crash in older versions because it was expecting a string before.

This `nextDistribution` was the date when the next CELO rewards distribution would be made. This is always the following Monday, since that's the cutoff date, so instead of having that value on Firebase now we are just calculating it in the client directly. This will make sure it's always up to date and we don't forget to update it as well.

### Tested

Manually.

### Related issues

- Fixes #64

### Backwards compatibility

Yes