### PR TITLE
Add proguard rules for InAppBrowser on Android

### DIFF
--- a/packages/mobile/android/app/proguard-rules.pro
+++ b/packages/mobile/android/app/proguard-rules.pro
@@ -44,3 +44,9 @@
 
 # react-native-reanimated
 -keep class com.facebook.react.turbomodule.** { *; }
+
+-keepattributes *Annotation*
+-keepclassmembers class ** {
+  @org.greenrobot.eventbus.Subscribe <methods>;
+}
+-keep enum org.greenrobot.eventbus.ThreadMode { *; }


### PR DESCRIPTION
### Description

InAppBrowser was crashing. The error was this: https://sentry.io/organizations/celo/issues/2241119154/?project=1250733&query=is%3Aunresolved&statsPeriod=14d
which matches what someone else was seeing here: https://github.com/proyecto26/react-native-inappbrowser/issues/174 and the solution was to add the proguard rules.

### Other changes

N/A

### Tested

No. My Android device is not working properly right now 😓  I'll keep trying, but if someone can test this in release mode that would be great.

### Related issues

- Fixes https://github.com/celo-org/wallet/issues/70

### Backwards compatibility

N/A