### PR TITLE
Fix hash from branding repo

### DIFF
--- a/packages/mobile/scripts/sync_branding.sh
+++ b/packages/mobile/scripts/sync_branding.sh
@@ -21,7 +21,7 @@ echo $mobile_root
 cd "$mobile_root"
 
 # Please update the sha when valora branding updates are needed
-valora_branding_sha=4ae2770
+valora_branding_sha=d5976ff
 
 if [[ "$branding" == "valora" ]]; then
   # prevents git from asking credentials


### PR DESCRIPTION
### Description

I merged another PR with an error on the branding repo :( Fixed on the other one and by changing the hash here.

This should have probably been caught by CI, I assume it didn't because CI runs with the celo branding rather than the valora branding. Maybe there's something we could do there to avoid this in the future.
