### PR TITLE
Changed font size in FeeDrawer to regular (#111)

### DIFF
--- a/packages/mobile/src/components/FeeDrawer.tsx
+++ b/packages/mobile/src/components/FeeDrawer.tsx
@@ -178,7 +178,7 @@ const styles = StyleSheet.create({
     color: colors.dark,
   },
   dropDownText: {
-    ...fontStyles.small,
+    ...fontStyles.regular,
     color: colors.gray4,
   },
 })


### PR DESCRIPTION
### Description

Currently, the font size of the lines on the dropdown menu for fees in the Send confirmation screen is `small` (14px). Present PR changes this font size to `regular` (16px).

### Other changes

This alters every FeeDrawer instance, including confirmation screens during the Exchange, Withdraw, and Transfer flows.

Note that TotalLineItem.tsx has not been altered, and the conversion-rate line below totals remains size `small` as requested.

### Tested

Tested by sight on the simulator app. Examined both the confirmation screen in the Send flow and the Transaction Review screen from the home feed.

### Related issues

- Fixes #111 

### Backwards compatibility

N/A