### PR TITLE
Add tests for non-wallet packages to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -388,7 +388,7 @@ jobs:
           command: |
             mkdir -p test-results/jest
             yarn run lerna \
-              --ignore '@celo/wallet-*' \
+              --ignore @celo/mobile \
               run test
 
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -377,6 +377,23 @@ jobs:
           at: ~/app
       - run: ./scripts/ci_check_vulnerabilities.sh
 
+  general-tests:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: ~/app
+
+      - run:
+          name: jest tests
+          command: |
+            mkdir -p test-results/jest
+            yarn run lerna \
+              --ignore '@celo/wallet-*' \
+              run test
+
+      - store_test_results:
+          path: test-results
+
   mobile-test:
     <<: *defaults
     steps:
@@ -435,6 +452,9 @@ workflows:
       - vulnerability-checks:
           requires:
             - install_dependencies
+      - general-tests:
+          requires:
+            - lint-checks
       - mobile-test:
           requires:
             - lint-checks

--- a/packages/blockchain-api/test/blockscout.test.ts
+++ b/packages/blockchain-api/test/blockscout.test.ts
@@ -658,14 +658,14 @@ describe('Blockscout', () => {
           "type": "EXCHANGE",
         },
         Object {
-          "account": "0x6a0edf42f5e618bee697e7718fa05efb1ea5d11c",
-          "address": "0x6a0edf42f5e618bee697e7718fa05efb1ea5d11c",
+          "account": "0x8b7649116f169d2d2aebb6ea1a77f0baf31f2811",
+          "address": "0x8b7649116f169d2d2aebb6ea1a77f0baf31f2811",
           "amount": Object {
             "currencyCode": "cUSD",
             "timestamp": 1566346276000,
             "value": "-0.15",
           },
-          "block": "90792",
+          "block": "90719",
           "comment": "",
           "fees": Array [
             Object {
@@ -685,7 +685,7 @@ describe('Blockscout', () => {
               "type": "SECURITY_FEE",
             },
           ],
-          "hash": "0x21dd2c18ae6c80d61ffbddaa073f7cde7bbfe9436fdf5059b506f1686326afff",
+          "hash": "0x21dd2c18ae6c80d61ffbddaa073f7cde7bbfe9436fdf5059b506f1686326a2fb",
           "timestamp": 1566346276000,
           "type": "SENT",
         },
@@ -722,14 +722,14 @@ describe('Blockscout', () => {
           "type": "SENT",
         },
         Object {
-          "account": "0x8b7649116f169d2d2aebb6ea1a77f0baf31f2811",
-          "address": "0x8b7649116f169d2d2aebb6ea1a77f0baf31f2811",
+          "account": "0x6a0edf42f5e618bee697e7718fa05efb1ea5d11c",
+          "address": "0x6a0edf42f5e618bee697e7718fa05efb1ea5d11c",
           "amount": Object {
             "currencyCode": "cUSD",
             "timestamp": 1566346276000,
             "value": "-0.15",
           },
-          "block": "90719",
+          "block": "90792",
           "comment": "",
           "fees": Array [
             Object {
@@ -749,7 +749,7 @@ describe('Blockscout', () => {
               "type": "SECURITY_FEE",
             },
           ],
-          "hash": "0x21dd2c18ae6c80d61ffbddaa073f7cde7bbfe9436fdf5059b506f1686326a2fb",
+          "hash": "0x21dd2c18ae6c80d61ffbddaa073f7cde7bbfe9436fdf5059b506f1686326afff",
           "timestamp": 1566346276000,
           "type": "SENT",
         },

--- a/packages/notification-service/test/firebase.test.ts
+++ b/packages/notification-service/test/firebase.test.ts
@@ -47,7 +47,7 @@ describe('sendPaymentNotification', () => {
               "color": "#42D689",
               "icon": "ic_stat_rings",
             },
-            "priority": "high",
+            "priority": "normal",
             "ttl": 604800000,
           },
           "data": Object {


### PR DESCRIPTION
### Description

After moving out of the monorepo, looks like tests for packages other than mobile were not running. Added those tests again.

### Other changes

N/A

### Tested

See that the tests are running now under `general-test`

### Related issues

- N/A

### Backwards compatibility

N/A