### PR TITLE
Wait for both navigator refs to be initialized

### DIFF
--- a/packages/mobile/src/navigator/NavigationService.ts
+++ b/packages/mobile/src/navigator/NavigationService.ts
@@ -16,7 +16,7 @@ import Logger from 'src/utils/Logger'
 
 const TAG = 'NavigationService'
 
-const NAVIGATOR_INIT_RETRIES = 5
+const NAVIGATOR_INIT_RETRIES = 10
 
 type SafeNavigate = typeof navigate
 
@@ -27,8 +27,7 @@ navigatorIsReadyRef.current = false
 async function ensureNavigator() {
   let retries = 0
   while (
-    !navigationRef.current &&
-    !navigatorIsReadyRef.current &&
+    (!navigationRef.current || !navigatorIsReadyRef.current) &&
     retries < NAVIGATOR_INIT_RETRIES
   ) {
     await sleep(200)


### PR DESCRIPTION
### Description

Sometimes the deep link gets missed when it gets sent while the app is initializing. To reproduce this swipe the app away and send a deep link to it.

### Other changes

I also increased the number of retries we wait for the navigator to be initialized just to be safe.

### Tested

Swipe the app away and launch it using a deep link using the script ./scripts/adb-deep-link.sh which sends a pay inte

### Related issues

- Fixes #128 

### Backwards compatibility

Yes.
