### PR TITLE
Add Bitfy and FlowBTC as providers for Brazil

### DIFF
--- a/packages/mobile/locales/en-US/fiatExchangeFlow.json
+++ b/packages/mobile/locales/en-US/fiatExchangeFlow.json
@@ -26,6 +26,8 @@
   "receiveWithPonto": "GCash (with Ponto)",
   "receiveWithKotani": "M-PESA (with Kotani Pay)",
   "receiveWithBidali": "Gift Cards and Mobile Top Up",
+  "bitfy": "Bitfy",
+  "flowBtc": "FlowBTC",
   "fundingEducationDialog": {
     "title": "Funding {{appName}}",
     "body": "{{appName}} is powered by the Celo Network. {{appName}} runs on Celo Dollars (cUSD), a stable digital currency tracking the US Dollar.\n\nTo fund your {{appName}} wallet, purchase cUSD from one of the 3rd party providers available in your location. For more information please visit <0>{{link}}</0>",

--- a/packages/mobile/src/app/reducers.ts
+++ b/packages/mobile/src/app/reducers.ts
@@ -18,6 +18,8 @@ export interface State {
   minVersion: string | null
   pontoEnabled: boolean
   kotaniEnabled: boolean
+  bitfyUrl: string | null
+  flowBtcUrl: string | null
   celoEducationUri: string | null
   shortVerificationCodesEnabled: boolean
   inviteModalVisible: boolean
@@ -38,6 +40,8 @@ const initialState = {
   minVersion: null,
   pontoEnabled: false,
   kotaniEnabled: false,
+  bitfyUrl: null,
+  flowBtcUrl: null,
   shortVerificationCodesEnabled: false,
   celoEducationUri: null,
   inviteModalVisible: false,
@@ -141,6 +145,8 @@ export const appReducer = (
         ...state,
         pontoEnabled: action.flags.pontoEnabled,
         kotaniEnabled: action.flags.kotaniEnabled,
+        bitfyUrl: action.flags.bitfyUrl,
+        flowBtcUrl: action.flags.flowBtcUrl,
         celoEducationUri: action.flags.celoEducationUri,
         shortVerificationCodesEnabled: action.flags.shortVerificationCodesEnabled,
       }

--- a/packages/mobile/src/app/saga.ts
+++ b/packages/mobile/src/app/saga.ts
@@ -90,6 +90,8 @@ export function* appVersionSaga() {
 export interface RemoteFeatureFlags {
   kotaniEnabled: boolean
   pontoEnabled: boolean
+  bitfyUrl: string | null
+  flowBtcUrl: string | null
   celoEducationUri: string | null
   shortVerificationCodesEnabled: boolean
   inviteRewardCusd: number

--- a/packages/mobile/src/app/selectors.ts
+++ b/packages/mobile/src/app/selectors.ts
@@ -43,8 +43,9 @@ export const verificationPossibleSelector = (state: RootState): boolean => {
 export const numberVerifiedSelector = (state: RootState) => state.app.numberVerified
 
 export const pontoEnabledSelector = (state: RootState) => state.app.pontoEnabled
-
 export const kotaniEnabledSelector = (state: RootState) => state.app.kotaniEnabled
+export const bitfyUrlSelector = (state: RootState) => state.app.bitfyUrl
+export const flowBtcUrlSelector = (state: RootState) => state.app.flowBtcUrl
 
 export const shortVerificationCodesEnabledSelector = (state: RootState) =>
   state.app.shortVerificationCodesEnabled

--- a/packages/mobile/src/fiatExchanges/FiatExchangeOptions.tsx
+++ b/packages/mobile/src/fiatExchanges/FiatExchangeOptions.tsx
@@ -14,7 +14,12 @@ import { TouchableWithoutFeedback } from 'react-native-gesture-handler'
 import { useSelector } from 'react-redux'
 import { FiatExchangeEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
-import { kotaniEnabledSelector, pontoEnabledSelector } from 'src/app/selectors'
+import {
+  bitfyUrlSelector,
+  flowBtcUrlSelector,
+  kotaniEnabledSelector,
+  pontoEnabledSelector,
+} from 'src/app/selectors'
 import BackButton from 'src/components/BackButton'
 import { KOTANI_URI, PONTO_URI } from 'src/config'
 import FundingEducationDialog from 'src/fiatExchanges/FundingEducationDialog'
@@ -36,6 +41,8 @@ export enum PaymentMethod {
   ADDRESS = 'ADDRESS',
   PONTO = 'PONTO',
   KOTANI = 'KOTANI',
+  BITFY = 'BITFY',
+  FLOW_BTC = 'FLOW_BTC',
   GIFT_CARD = 'GIFT_CARD',
 }
 
@@ -118,11 +125,21 @@ function PaymentMethodRadioItem({
 function FiatExchangeOptions({ route, navigation }: Props) {
   const { t } = useTranslation(Namespaces.fiatExchangeFlow)
   const isCashIn = route.params?.isCashIn ?? true
-  const { MOONPAY_DISABLED, KOTANI_SUPPORTED, PONTO_SUPPORTED } = useCountryFeatures()
+  const {
+    MOONPAY_DISABLED,
+    KOTANI_SUPPORTED,
+    PONTO_SUPPORTED,
+    BITFY_SUPPORTED,
+    FLOW_BTC_SUPPORTED,
+  } = useCountryFeatures()
   const pontoEnabled = useSelector(pontoEnabledSelector)
   const kotaniEnabled = useSelector(kotaniEnabledSelector)
+  const bitfyUrl = useSelector(bitfyUrlSelector)
+  const flowBtcUrl = useSelector(flowBtcUrlSelector)
   const showPonto = pontoEnabled && PONTO_SUPPORTED
   const showKotani = kotaniEnabled && KOTANI_SUPPORTED
+  const showBitfy = bitfyUrl && BITFY_SUPPORTED
+  const showFlowBtc = flowBtcUrl && FLOW_BTC_SUPPORTED
 
   Logger.debug(`Ponto: ${pontoEnabled} Kotani: ${kotaniEnabled}`)
 
@@ -147,6 +164,10 @@ function FiatExchangeOptions({ route, navigation }: Props) {
       navigate(Screens.LocalProviderCashOut, { uri: PONTO_URI })
     } else if (selectedPaymentMethod === PaymentMethod.KOTANI) {
       navigate(Screens.LocalProviderCashOut, { uri: KOTANI_URI })
+    } else if (selectedPaymentMethod === PaymentMethod.BITFY && bitfyUrl) {
+      navigate(Screens.LocalProviderCashOut, { uri: bitfyUrl })
+    } else if (selectedPaymentMethod === PaymentMethod.FLOW_BTC && flowBtcUrl) {
+      navigate(Screens.LocalProviderCashOut, { uri: flowBtcUrl })
     } else if (selectedPaymentMethod === PaymentMethod.GIFT_CARD) {
       navigate(Screens.BidaliScreen, { currency: selectedCurrency })
     } else if (selectedPaymentMethod === PaymentMethod.ADDRESS) {
@@ -266,6 +287,22 @@ function FiatExchangeOptions({ route, navigation }: Props) {
                 />
               )}
             </>
+          )}
+          {showBitfy && (
+            <PaymentMethodRadioItem
+              text={t('bitfy')}
+              selected={selectedPaymentMethod === PaymentMethod.BITFY}
+              onSelect={onSelectPaymentMethod(PaymentMethod.BITFY)}
+              enabled={true}
+            />
+          )}
+          {showFlowBtc && (
+            <PaymentMethodRadioItem
+              text={t('flowBtc')}
+              selected={selectedPaymentMethod === PaymentMethod.FLOW_BTC}
+              onSelect={onSelectPaymentMethod(PaymentMethod.FLOW_BTC)}
+              enabled={true}
+            />
           )}
         </View>
         <Button

--- a/packages/mobile/src/firebase/firebase.ts
+++ b/packages/mobile/src/firebase/firebase.ts
@@ -218,6 +218,8 @@ export function appRemoteFeatureFlagChannel() {
       emit({
         kotaniEnabled: flags?.kotaniEnabled || false,
         pontoEnabled: flags?.pontoEnabled || false,
+        bitfyUrl: flags?.bitfyUrl ?? null,
+        flowBtcUrl: flags?.flowBtcUrl ?? null,
         celoEducationUri: flags?.celoEducationUri ?? null,
         shortVerificationCodesEnabled: flags?.shortVerificationCodesEnabled ?? false,
         inviteRewardsEnabled: flags?.inviteRewardsEnabled ?? false,

--- a/packages/mobile/src/flags.ts
+++ b/packages/mobile/src/flags.ts
@@ -40,6 +40,12 @@ export const countryFeatures = {
   KOTANI_SUPPORTED: {
     KE: true,
   },
+  BITFY_SUPPORTED: {
+    BR: true,
+  },
+  FLOW_BTC_SUPPORTED: {
+    BR: true,
+  },
   FIAT_SPEND_ENABLED: {
     PH: true,
   },

--- a/packages/mobile/src/utils/countryFeatures.test.ts
+++ b/packages/mobile/src/utils/countryFeatures.test.ts
@@ -12,7 +12,9 @@ describe(getCountryFeaturesSelector, () => {
 
     expect(getCountryFeaturesSelector(state)).toMatchInlineSnapshot(`
       Object {
+        "BITFY_SUPPORTED": false,
         "FIAT_SPEND_ENABLED": false,
+        "FLOW_BTC_SUPPORTED": false,
         "KOTANI_SUPPORTED": false,
         "MOONPAY_DISABLED": true,
         "PONTO_SUPPORTED": false,
@@ -31,7 +33,9 @@ describe(getCountryFeaturesSelector, () => {
 
     expect(getCountryFeaturesSelector(state)).toMatchInlineSnapshot(`
       Object {
+        "BITFY_SUPPORTED": false,
         "FIAT_SPEND_ENABLED": true,
+        "FLOW_BTC_SUPPORTED": false,
         "KOTANI_SUPPORTED": false,
         "MOONPAY_DISABLED": false,
         "PONTO_SUPPORTED": true,
@@ -50,7 +54,9 @@ describe(getCountryFeaturesSelector, () => {
 
     expect(getCountryFeaturesSelector(state)).toMatchInlineSnapshot(`
       Object {
+        "BITFY_SUPPORTED": false,
         "FIAT_SPEND_ENABLED": false,
+        "FLOW_BTC_SUPPORTED": false,
         "KOTANI_SUPPORTED": false,
         "MOONPAY_DISABLED": false,
         "PONTO_SUPPORTED": false,
@@ -69,12 +75,35 @@ describe(getCountryFeaturesSelector, () => {
 
     expect(getCountryFeaturesSelector(state)).toMatchInlineSnapshot(`
       Object {
+        "BITFY_SUPPORTED": false,
         "FIAT_SPEND_ENABLED": false,
+        "FLOW_BTC_SUPPORTED": false,
         "KOTANI_SUPPORTED": false,
         "MOONPAY_DISABLED": false,
         "PONTO_SUPPORTED": false,
         "RESTRICTED_CP_DOTO": false,
         "SANCTIONED_COUNTRY": true,
+      }
+    `)
+  })
+
+  it('returns the appropriate features for BR accounts', () => {
+    const state = getMockStoreData({
+      account: {
+        defaultCountryCode: '+55',
+      },
+    })
+
+    expect(getCountryFeaturesSelector(state)).toMatchInlineSnapshot(`
+      Object {
+        "BITFY_SUPPORTED": true,
+        "FIAT_SPEND_ENABLED": false,
+        "FLOW_BTC_SUPPORTED": true,
+        "KOTANI_SUPPORTED": false,
+        "MOONPAY_DISABLED": false,
+        "PONTO_SUPPORTED": false,
+        "RESTRICTED_CP_DOTO": false,
+        "SANCTIONED_COUNTRY": false,
       }
     `)
   })

--- a/packages/mobile/test/schemas.ts
+++ b/packages/mobile/test/schemas.ts
@@ -473,6 +473,8 @@ export const v7Schema = {
     ...v6Schema.app,
     activeScreen: '',
     celoEducationUri: null,
+    bitfyUrl: null,
+    flowBtcUrl: null,
     shortVerificationCodesEnabled: false,
   },
   account: {


### PR DESCRIPTION
### Description

Added two new cash in/out providers for Brazil. These integrations are just a link to a WebView for those providers like the ones we have for Ponto and Kotani.

### Other changes

N/A

### Tested

Manually by using a  BR number (and checking it doesn't show up for other countries)

### Related issues

- Fixes #7449

### Backwards compatibility

N/A