### PR TITLE
Enable CELO cash-in for all users

### DIFF
--- a/packages/mobile/src/fiatExchanges/FiatExchangeOptions.tsx
+++ b/packages/mobile/src/fiatExchanges/FiatExchangeOptions.tsx
@@ -143,7 +143,6 @@ function FiatExchangeOptions({ route, navigation }: Props) {
 
   Logger.debug(`Ponto: ${pontoEnabled} Kotani: ${kotaniEnabled}`)
 
-  const isCeloCashInOptionAvailable = !MOONPAY_DISABLED
   const [selectedCurrency, setSelectedCurrency] = useState<CURRENCY_ENUM>(CURRENCY_ENUM.DOLLAR)
   const [selectedPaymentMethod, setSelectedPaymentMethod] = useState<PaymentMethod>(
     isCashIn ? PaymentMethod.FIAT : PaymentMethod.EXCHANGE
@@ -227,11 +226,7 @@ function FiatExchangeOptions({ route, navigation }: Props) {
               borderBottomLeftRadius: 8,
               borderBottomRightRadius: 8,
             }}
-            enabled={
-              isCeloCashInOptionAvailable ||
-              (selectedPaymentMethod !== PaymentMethod.FIAT &&
-                selectedPaymentMethod !== PaymentMethod.GIFT_CARD)
-            }
+            enabled={selectedPaymentMethod !== PaymentMethod.GIFT_CARD}
           />
         </View>
       </ScrollView>
@@ -245,10 +240,6 @@ function FiatExchangeOptions({ route, navigation }: Props) {
               text={t('payWithFiat')}
               selected={selectedPaymentMethod === PaymentMethod.FIAT}
               onSelect={onSelectPaymentMethod(PaymentMethod.FIAT)}
-              enabled={
-                selectedCurrency === CURRENCY_ENUM.DOLLAR ||
-                (selectedCurrency === CURRENCY_ENUM.GOLD && isCeloCashInOptionAvailable)
-              }
             />
           )}
           <PaymentMethodRadioItem

--- a/packages/mobile/src/fiatExchanges/FiatExchangeOptions.tsx
+++ b/packages/mobile/src/fiatExchanges/FiatExchangeOptions.tsx
@@ -126,7 +126,6 @@ function FiatExchangeOptions({ route, navigation }: Props) {
   const { t } = useTranslation(Namespaces.fiatExchangeFlow)
   const isCashIn = route.params?.isCashIn ?? true
   const {
-    MOONPAY_DISABLED,
     KOTANI_SUPPORTED,
     PONTO_SUPPORTED,
     BITFY_SUPPORTED,

--- a/packages/mobile/src/fiatExchanges/ProviderOptionsScreen.test.tsx
+++ b/packages/mobile/src/fiatExchanges/ProviderOptionsScreen.test.tsx
@@ -118,7 +118,7 @@ describe('ProviderOptionsScreen', () => {
     })
   })
 
-  it('opens Transak correctly', async () => {
+  xit('opens Transak correctly', async () => {
     mockFetch.mockResponseOnce(UNRESTRICTED_USER_LOCATION)
 
     const tree = render(

--- a/packages/mobile/src/fiatExchanges/ProviderOptionsScreen.tsx
+++ b/packages/mobile/src/fiatExchanges/ProviderOptionsScreen.tsx
@@ -125,12 +125,9 @@ function ProviderOptionsScreen({ route, navigation }: Props) {
 
   const userLocation: UserLocation | undefined = asyncUserLocation.result
 
-  const {
-    MOONPAY_RESTRICTED,
-    SIMPLEX_RESTRICTED,
-    RAMP_RESTRICTED,
-    TRANSAK_RESTRICTED,
-  } = getProviderAvailability(userLocation)
+  const { MOONPAY_RESTRICTED, SIMPLEX_RESTRICTED, RAMP_RESTRICTED } = getProviderAvailability(
+    userLocation
+  )
 
   const providers: {
     cashOut: Provider[]

--- a/packages/mobile/src/fiatExchanges/ProviderOptionsScreen.tsx
+++ b/packages/mobile/src/fiatExchanges/ProviderOptionsScreen.tsx
@@ -24,7 +24,7 @@ import {
   openMoonpay,
   openRamp,
   openSimplex,
-  openTransak,
+  sortProviders,
   UserLocation,
 } from 'src/fiatExchanges/utils'
 import { CURRENCY_ENUM } from 'src/geth/consts'
@@ -58,7 +58,7 @@ ProviderOptionsScreen.navigationOptions = ({
   }
 }
 
-interface Provider {
+export interface Provider {
   id: CiCoProvider
   restricted: boolean
   image?: React.ReactNode
@@ -155,13 +155,14 @@ function ProviderOptionsScreen({ route, navigation }: Props) {
         onSelected: () =>
           openRamp(route.params.amount, localCurrency || FALLBACK_CURRENCY, selectedCurrency),
       },
-      {
-        id: CiCoProvider.Transak,
-        restricted: TRANSAK_RESTRICTED,
-        onSelected: () =>
-          openTransak(route.params.amount, localCurrency || FALLBACK_CURRENCY, selectedCurrency),
-      },
-    ],
+      // Commenting out until we have completed KYB for Transak
+      // {
+      //   id: CiCoProvider.Transak,
+      //   restricted: TRANSAK_RESTRICTED,
+      //   onSelected: () =>
+      //     openTransak(route.params.amount, localCurrency || FALLBACK_CURRENCY, selectedCurrency),
+      // },
+    ].sort(sortProviders),
   }
 
   const providerOnPress = (provider: Provider) => () => {

--- a/packages/mobile/src/fiatExchanges/__snapshots__/FiatExchangeOptions.test.tsx.snap
+++ b/packages/mobile/src/fiatExchanges/__snapshots__/FiatExchangeOptions.test.tsx.snap
@@ -235,7 +235,7 @@ exports[`FiatExchangeOptions renders correctly 1`] = `
                   cx="10"
                   cy="10"
                   r="9"
-                  stroke="#EDEEEF"
+                  stroke="#B4B9BD"
                   strokeWidth={2}
                   style={Object {}}
                 />
@@ -256,9 +256,7 @@ exports[`FiatExchangeOptions renders correctly 1`] = `
                       "lineHeight": 22,
                       "marginLeft": 16,
                     },
-                    Object {
-                      "color": "#B4B9BD",
-                    },
+                    Object {},
                   ]
                 }
               >

--- a/packages/mobile/src/fiatExchanges/__snapshots__/ProviderOptionsScreen.test.tsx.snap
+++ b/packages/mobile/src/fiatExchanges/__snapshots__/ProviderOptionsScreen.test.tsx.snap
@@ -100,101 +100,6 @@ exports[`ProviderOptionsScreen renders correctly 2`] = `
                     "justifyContent": "space-between",
                   }
                 }
-                testID="Provider/Moonpay"
-              >
-                <View
-                  style={
-                    Object {
-                      "flexDirection": "column",
-                      "justifyContent": "space-between",
-                    }
-                  }
-                >
-                  <Text
-                    style={
-                      Object {
-                        "color": "#2E3338",
-                        "fontFamily": "Inter-Regular",
-                        "fontSize": 16,
-                        "lineHeight": 22,
-                      }
-                    }
-                  >
-                    Moonpay
-                  </Text>
-                  <Text
-                    style={
-                      Object {
-                        "color": "#9CA4A9",
-                        "fontFamily": "Inter-Regular",
-                        "fontSize": 14,
-                        "lineHeight": 18,
-                      }
-                    }
-                  >
-                    restrictedRegion
-                  </Text>
-                </View>
-                <Image
-                  source={
-                    Object {
-                      "testUri": "../../../packages/mobile/src/images/link-arrow.png",
-                    }
-                  }
-                  style={
-                    Object {
-                      "height": 32,
-                      "width": 32,
-                    }
-                  }
-                />
-              </View>
-            </View>
-          </View>
-        </View>
-        <View
-          style={
-            Object {
-              "backgroundColor": "#FFFFFF",
-            }
-          }
-        >
-          <View
-            accessible={true}
-            focusable={true}
-            nativeBackgroundAndroid={
-              Object {
-                "attribute": "selectableItemBackgroundBorderless",
-                "rippleRadius": undefined,
-                "type": "ThemeAttrAndroid",
-              }
-            }
-            onClick={[Function]}
-            onResponderGrant={[Function]}
-            onResponderMove={[Function]}
-            onResponderRelease={[Function]}
-            onResponderTerminate={[Function]}
-            onResponderTerminationRequest={[Function]}
-            onStartShouldSetResponder={[Function]}
-          >
-            <View
-              style={
-                Object {
-                  "borderBottomColor": "#EDEEEF",
-                  "borderBottomWidth": 1,
-                  "marginLeft": 16,
-                  "paddingVertical": 16,
-                }
-              }
-            >
-              <View
-                style={
-                  Object {
-                    "alignItems": "center",
-                    "flexDirection": "row",
-                    "justifyContent": "space-between",
-                  }
-                }
                 testID="Provider/Simplex"
               >
                 <View
@@ -373,7 +278,7 @@ exports[`ProviderOptionsScreen renders correctly 2`] = `
                     "justifyContent": "space-between",
                   }
                 }
-                testID="Provider/Transak"
+                testID="Provider/Moonpay"
               >
                 <View
                   style={
@@ -393,7 +298,7 @@ exports[`ProviderOptionsScreen renders correctly 2`] = `
                       }
                     }
                   >
-                    Transak
+                    Moonpay
                   </Text>
                   <Text
                     style={

--- a/packages/mobile/src/fiatExchanges/utils.tsx
+++ b/packages/mobile/src/fiatExchanges/utils.tsx
@@ -6,7 +6,7 @@ import {
   PROVIDER_URL_COMPOSER_STAGING,
   SIMPLEX_URI,
 } from 'src/config'
-import { Providers } from 'src/fiatExchanges/ProviderOptionsScreen'
+import { Provider, Providers } from 'src/fiatExchanges/ProviderOptionsScreen'
 import { providerAvailability } from 'src/flags'
 import { LocalCurrencyCode } from 'src/localCurrency/consts'
 import { navigate } from 'src/navigator/NavigationService'
@@ -129,4 +129,13 @@ export function getProviderAvailability(
     }
   }
   return features
+}
+
+// Leaving unoptimized for now because sorting is most relevant when fees will be visible
+export const sortProviders = (provider1: Provider, provider2: Provider) => {
+  if (provider1.restricted) {
+    return 1
+  }
+
+  return -1
 }


### PR DESCRIPTION
### Description
This PR allows all users to cash-in CELO (previously it was only allowed if Moonpay was enabled in their region).

### Other changes
- Sorts provider options by availability
- Comments out Transak as we've yet to clear its KYB check

### Tested
Manual - more to be added in subsequent PR

### Related issues
- Fixes #144 

### Backwards compatibility
Yes