### PR TITLE
Display escrow payment details

### DIFF
--- a/packages/mobile/locales/en-US/walletFlow5.json
+++ b/packages/mobile/locales/en-US/walletFlow5.json
@@ -97,7 +97,7 @@
   "feedItemEscrowSentTitle": "{{nameOrNumber}}",
   "feedItemEscrowSentTitle_noReceiverDetails": "Unknown",
   "feedItemEscrowSentInfo": "{{comment}}",
-  "feedItemEscrowSentInfo_noComment": "Escrow Payment Sent",
+  "feedItemEscrowSentInfo_noComment": "Invite Sent",
   "feedItemEscrowReceivedTitle": "{{nameOrNumber}}",
   "feedItemEscrowReceivedTitle_noSenderDetails": "Unknown",
   "feedItemEscrowReceivedInfo": "{{comment}}",

--- a/packages/mobile/src/invite/saga.test.ts
+++ b/packages/mobile/src/invite/saga.test.ts
@@ -29,6 +29,7 @@ import {
   generateInviteLink,
   initiateEscrowTransfer,
   moveAllFundsFromAccount,
+  sendInvite as sendInviteSaga,
   watchRedeemInvite,
   watchSendInvite,
 } from 'src/invite/saga'
@@ -82,6 +83,7 @@ jest.mock('src/config', () => {
   return {
     ...(jest.requireActual('src/config') as any),
     APP_STORE_ID: '1482389446',
+    DYNAMIC_DOWNLOAD_LINK: 'http://celo.page.link/PARAMS',
   }
 })
 
@@ -262,6 +264,18 @@ describe('watchSendInvite with Komenci enabled', () => {
       link: WEB_LINK,
     })
     expect(Share.share).toHaveBeenCalledWith({ message: 'sendFlow7:inviteWithEscrowedPayment' })
+  })
+
+  it('adds invitee details when sending invite', async () => {
+    await expectSaga(
+      sendInviteSaga,
+      mockInviteDetails.e164Number,
+      InviteBy.SMS,
+      AMOUNT_TO_SEND,
+      CURRENCY_ENUM.DOLLAR
+    )
+      .put(storeInviteeData(mockInviteDetails))
+      .run()
   })
 })
 

--- a/packages/mobile/src/invite/saga.ts
+++ b/packages/mobile/src/invite/saga.ts
@@ -203,14 +203,6 @@ export function* sendInvite(
       link,
     })
 
-    if (features.ESCROW_WITHOUT_CODE) {
-      if (amount) {
-        yield call(initiateEscrowTransfer, e164Number, amount, undefined, feeInfo)
-      }
-      yield call(Share.share, { message })
-      return
-    }
-
     const inviteDetails: InviteDetails = {
       timestamp: Date.now(),
       e164Number,
@@ -223,6 +215,14 @@ export function* sendInvite(
 
     // Store the Temp Address locally so we know which transactions were invites
     yield put(storeInviteeData(inviteDetails))
+
+    if (features.ESCROW_WITHOUT_CODE) {
+      if (amount) {
+        yield call(initiateEscrowTransfer, e164Number, amount, undefined, feeInfo)
+      }
+      yield call(Share.share, { message })
+      return
+    }
 
     let transferReceipt: CeloTxReceipt | undefined
     if (!features.KOMENCI) {


### PR DESCRIPTION
### Description

When an escrow payment is sent to an unverified number, the transaction now shows the contact name (will still display `Unknown` if phone number used is not in contacts, this will be fixed with the CIP8 PRs). Previously, these transactions were showing as `Unknown` because we weren't storing invitee information when the `ESCROW_WITHOUT_CODE` feature flag is set.

changed default escrow payment comment to "Invite Sent"

### Tested

yes, on Android

### Related issues

- Fixes #46 

### Backwards compatibility

Yes