### PR TITLE
Add flow for recovering access to account if Redux store is wiped

### DIFF
--- a/packages/mobile/locales/en-US/accountScreen10.json
+++ b/packages/mobile/locales/en-US/accountScreen10.json
@@ -69,5 +69,8 @@
   "addPhoto": "Add Photo",
   "chooseFromLibrary": "Choose from Library",
   "takePhoto": "Take Photo",
-  "removePhoto": "Remove Photo"
+  "removePhoto": "Remove Photo",
+  "storeRecoveryTitle": "We need you to setup your account again",
+  "storeRecoveryBody": "There’s been an error. We’re aware of the issue and working to fix it. In the meantime, you will need to go through the setup process again.",
+  "storeRecoveryButton": "Restore Account"
 }

--- a/packages/mobile/src/account/Settings.tsx
+++ b/packages/mobile/src/account/Settings.tsx
@@ -234,6 +234,11 @@ export class Account extends React.Component<Props, State> {
             </TouchableOpacity>
           </View>
           <View style={styles.devSettingsItem}>
+            <TouchableOpacity onPress={this.wipeReduxStore}>
+              <Text>Wipe Redux Store</Text>
+            </TouchableOpacity>
+          </View>
+          <View style={styles.devSettingsItem}>
             <TouchableOpacity onPress={this.confirmAccountRemoval}>
               <Text>Valora Quick Reset</Text>
             </TouchableOpacity>
@@ -305,6 +310,10 @@ export class Account extends React.Component<Props, State> {
 
   hideConfirmRemovalModal = () => {
     this.props.navigation.setParams({ promptConfirmRemovalModal: false })
+  }
+
+  wipeReduxStore = () => {
+    this.props.clearStoredAccount(this.props.account || '', true)
   }
 
   confirmAccountRemoval = () => {

--- a/packages/mobile/src/account/StoreWipeRecoveryScreen.tsx
+++ b/packages/mobile/src/account/StoreWipeRecoveryScreen.tsx
@@ -36,8 +36,8 @@ function StoreWipeRecoveryScreen({ route }: Props) {
   }
 
   return (
-    <View style={styles.container}>
-      <ScrollView contentContainerStyle={styles.content}>
+    <ScrollView style={styles.container}>
+      <SafeAreaView edges={['bottom']} style={styles.content}>
         <Text style={styles.title} testID={'StoreWipeRecovery'}>
           {t('storeRecoveryTitle')}
         </Text>
@@ -45,9 +45,8 @@ function StoreWipeRecoveryScreen({ route }: Props) {
         <TextButton onPress={goToOnboarding} testID="GoToOnboarding">
           {t('storeRecoveryButton')}
         </TextButton>
-      </ScrollView>
-      <KeyboardSpacer />
-    </View>
+      </SafeAreaView>
+    </ScrollView>
   )
 }
 

--- a/packages/mobile/src/account/StoreWipeRecoveryScreen.tsx
+++ b/packages/mobile/src/account/StoreWipeRecoveryScreen.tsx
@@ -1,11 +1,11 @@
-import KeyboardSpacer from '@celo/react-components/components/KeyboardSpacer'
 import TextButton from '@celo/react-components/components/TextButton'
 import fontStyles from '@celo/react-components/styles/fonts'
 import { Spacing } from '@celo/react-components/styles/styles'
 import { StackScreenProps } from '@react-navigation/stack'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
-import { ScrollView, StyleSheet, Text, View } from 'react-native'
+import { StyleSheet, Text } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
 import { useDispatch } from 'react-redux'
 import { startStoreWipeRecovery } from 'src/account/actions'
 import { Namespaces } from 'src/i18n'
@@ -28,7 +28,7 @@ function StoreWipeRecoveryScreen({ route }: Props) {
     try {
       const account = route.params.account
       await requestPincodeInput(true, false, account)
-      dispatch(startStoreWipeRecovery())
+      dispatch(startStoreWipeRecovery(account))
       navigate(Screens.NameAndPicture)
     } catch (error) {
       Logger.error(`${TAG}@goToOnboarding`, 'PIN error', error)
@@ -36,17 +36,15 @@ function StoreWipeRecoveryScreen({ route }: Props) {
   }
 
   return (
-    <ScrollView style={styles.container}>
-      <SafeAreaView edges={['bottom']} style={styles.content}>
-        <Text style={styles.title} testID={'StoreWipeRecovery'}>
-          {t('storeRecoveryTitle')}
-        </Text>
-        <Text style={styles.body}>{t('storeRecoveryBody')}</Text>
-        <TextButton onPress={goToOnboarding} testID="GoToOnboarding">
-          {t('storeRecoveryButton')}
-        </TextButton>
-      </SafeAreaView>
-    </ScrollView>
+    <SafeAreaView style={styles.content}>
+      <Text style={styles.title} testID={'StoreWipeRecovery'}>
+        {t('storeRecoveryTitle')}
+      </Text>
+      <Text style={styles.body}>{t('storeRecoveryBody')}</Text>
+      <TextButton onPress={goToOnboarding} testID="GoToOnboarding">
+        {t('storeRecoveryButton')}
+      </TextButton>
+    </SafeAreaView>
   )
 }
 

--- a/packages/mobile/src/account/StoreWipeRecoveryScreen.tsx
+++ b/packages/mobile/src/account/StoreWipeRecoveryScreen.tsx
@@ -1,0 +1,81 @@
+import KeyboardSpacer from '@celo/react-components/components/KeyboardSpacer'
+import TextButton from '@celo/react-components/components/TextButton'
+import fontStyles from '@celo/react-components/styles/fonts'
+import { Spacing } from '@celo/react-components/styles/styles'
+import { StackScreenProps } from '@react-navigation/stack'
+import React from 'react'
+import { useTranslation } from 'react-i18next'
+import { ScrollView, StyleSheet, Text, View } from 'react-native'
+import { useDispatch } from 'react-redux'
+import { startStoreWipeRecovery } from 'src/account/actions'
+import { Namespaces } from 'src/i18n'
+import { emptyHeader } from 'src/navigator/Headers'
+import { navigate } from 'src/navigator/NavigationService'
+import { Screens } from 'src/navigator/Screens'
+import { StackParamList } from 'src/navigator/types'
+import { requestPincodeInput } from 'src/pincode/authentication'
+import Logger from 'src/utils/Logger'
+
+type Props = StackScreenProps<StackParamList, Screens.StoreWipeRecoveryScreen>
+
+const TAG = 'StoreWipeRecoveryScreen'
+
+function StoreWipeRecoveryScreen({ route }: Props) {
+  const { t } = useTranslation(Namespaces.accountScreen10)
+  const dispatch = useDispatch()
+
+  const goToOnboarding = async () => {
+    try {
+      const account = route.params.account
+      await requestPincodeInput(true, false, account)
+      dispatch(startStoreWipeRecovery())
+      navigate(Screens.NameAndPicture)
+    } catch (error) {
+      Logger.error(`${TAG}@goToOnboarding`, 'PIN error', error)
+    }
+  }
+
+  return (
+    <View style={styles.container}>
+      <ScrollView contentContainerStyle={styles.content}>
+        <Text style={styles.title} testID={'StoreWipeRecovery'}>
+          {t('storeRecoveryTitle')}
+        </Text>
+        <Text style={styles.body}>{t('storeRecoveryBody')}</Text>
+        <TextButton onPress={goToOnboarding} testID="GoToOnboarding">
+          {t('storeRecoveryButton')}
+        </TextButton>
+      </ScrollView>
+      <KeyboardSpacer />
+    </View>
+  )
+}
+
+StoreWipeRecoveryScreen.navOptions = {
+  ...emptyHeader,
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  content: {
+    flex: 1,
+    marginHorizontal: Spacing.Thick24,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  title: {
+    ...fontStyles.h2,
+    textAlign: 'center',
+    paddingBottom: Spacing.Regular16,
+    paddingTop: Spacing.Regular16,
+  },
+  body: {
+    ...fontStyles.regular,
+    textAlign: 'center',
+    paddingBottom: Spacing.Thick24,
+  },
+})
+
+export default StoreWipeRecoveryScreen

--- a/packages/mobile/src/account/__snapshots__/Settings.test.tsx.snap
+++ b/packages/mobile/src/account/__snapshots__/Settings.test.tsx.snap
@@ -3601,6 +3601,38 @@ exports[`Account renders correctly when dev mode active 1`] = `
             }
           >
             <Text>
+              Wipe Redux Store
+            </Text>
+          </View>
+        </View>
+        <View
+          style={
+            Object {
+              "alignSelf": "stretch",
+              "margin": 4,
+            }
+          }
+        >
+          <View
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Array [
+                undefined,
+                Object {
+                  "opacity": 1,
+                },
+              ]
+            }
+          >
+            <Text>
               Valora Quick Reset
             </Text>
           </View>

--- a/packages/mobile/src/account/actions.ts
+++ b/packages/mobile/src/account/actions.ts
@@ -3,6 +3,7 @@ import { PincodeType } from 'src/account/reducer'
 export enum Actions {
   CHOOSE_CREATE_ACCOUNT = 'ACCOUNT/CHOOSE_CREATE',
   CHOOSE_RESTORE_ACCOUNT = 'ACCOUNT/CHOOSE_RESTORE',
+  START_STORE_WIPE_RECOVERY = 'ACCOUNT/START_STORE_WIPE_RECOVERY',
   CANCEL_CREATE_OR_RESTORE_ACCOUNT = 'ACCOUNT/CANCEL_CREATE_OR_RESTORE_ACCOUNT',
   SET_NAME = 'ACCOUNT/SET_NAME',
   SET_PHONE_NUMBER = 'ACCOUNT/SET_PHONE_NUMBER',
@@ -36,6 +37,10 @@ export interface ChooseCreateAccountAction {
 }
 export interface ChooseRestoreAccountAction {
   type: Actions.CHOOSE_RESTORE_ACCOUNT
+}
+
+export interface StartStoreWipeRecoveryAction {
+  type: Actions.START_STORE_WIPE_RECOVERY
 }
 
 export interface CancelCreateOrRestoreAccountAction {
@@ -149,6 +154,7 @@ export interface SetRetryVerificationWithFornoAction {
 export interface ClearStoredAccountAction {
   type: Actions.CLEAR_STORED_ACCOUNT
   account: string
+  softDelete: boolean
 }
 
 export interface UpdateDailyLimitAction {
@@ -159,6 +165,7 @@ export interface UpdateDailyLimitAction {
 export type ActionTypes =
   | ChooseCreateAccountAction
   | ChooseRestoreAccountAction
+  | StartStoreWipeRecoveryAction
   | CancelCreateOrRestoreAccountAction
   | SetNameAction
   | SetPhoneNumberAction
@@ -195,6 +202,12 @@ export function chooseCreateAccount(): ChooseCreateAccountAction {
 export function chooseRestoreAccount(): ChooseRestoreAccountAction {
   return {
     type: Actions.CHOOSE_RESTORE_ACCOUNT,
+  }
+}
+
+export function startStoreWipeRecovery(): StartStoreWipeRecoveryAction {
+  return {
+    type: Actions.START_STORE_WIPE_RECOVERY,
   }
 }
 
@@ -326,9 +339,13 @@ export const setUserContactDetails = (
   thumbnailPath,
 })
 
-export const clearStoredAccount = (account: string): ClearStoredAccountAction => ({
+export const clearStoredAccount = (
+  account: string,
+  softDelete: boolean = false
+): ClearStoredAccountAction => ({
   type: Actions.CLEAR_STORED_ACCOUNT,
   account,
+  softDelete,
 })
 
 export const updateCusdDailyLimit = (newLimit: number): UpdateDailyLimitAction => ({

--- a/packages/mobile/src/account/actions.ts
+++ b/packages/mobile/src/account/actions.ts
@@ -41,6 +41,7 @@ export interface ChooseRestoreAccountAction {
 
 export interface StartStoreWipeRecoveryAction {
   type: Actions.START_STORE_WIPE_RECOVERY
+  accountToRecover: string
 }
 
 export interface CancelCreateOrRestoreAccountAction {
@@ -154,7 +155,7 @@ export interface SetRetryVerificationWithFornoAction {
 export interface ClearStoredAccountAction {
   type: Actions.CLEAR_STORED_ACCOUNT
   account: string
-  softDelete: boolean
+  onlyReduxState: boolean
 }
 
 export interface UpdateDailyLimitAction {
@@ -205,9 +206,10 @@ export function chooseRestoreAccount(): ChooseRestoreAccountAction {
   }
 }
 
-export function startStoreWipeRecovery(): StartStoreWipeRecoveryAction {
+export function startStoreWipeRecovery(accountToRecover: string): StartStoreWipeRecoveryAction {
   return {
     type: Actions.START_STORE_WIPE_RECOVERY,
+    accountToRecover,
   }
 }
 
@@ -341,11 +343,11 @@ export const setUserContactDetails = (
 
 export const clearStoredAccount = (
   account: string,
-  softDelete: boolean = false
+  onlyReduxState: boolean = false
 ): ClearStoredAccountAction => ({
   type: Actions.CLEAR_STORED_ACCOUNT,
   account,
-  softDelete,
+  onlyReduxState,
 })
 
 export const updateCusdDailyLimit = (newLimit: number): UpdateDailyLimitAction => ({

--- a/packages/mobile/src/account/reducer.ts
+++ b/packages/mobile/src/account/reducer.ts
@@ -30,6 +30,7 @@ export interface State {
   acceptedTerms: boolean
   hasMigratedToNewBip39: boolean
   choseToRestoreAccount: boolean | undefined
+  recoveringFromStoreWipe: boolean
   dailyLimitCusd: number
 }
 
@@ -68,6 +69,7 @@ export const initialState = {
   retryVerificationWithForno: features.VERIFICATION_FORNO_RETRY,
   hasMigratedToNewBip39: false,
   choseToRestoreAccount: false,
+  recoveringFromStoreWipe: false,
   dailyLimitCusd: DEFAULT_DAILY_PAYMENT_LIMIT_CUSD,
 }
 
@@ -96,10 +98,19 @@ export const reducer = (
         ...state,
         choseToRestoreAccount: true,
       }
+    case Actions.START_STORE_WIPE_RECOVERY:
+      return {
+        ...state,
+        choseToRestoreAccount: true,
+        recoveringFromStoreWipe: true,
+        pincodeType: PincodeType.CustomPin,
+        acceptedTerms: true,
+      }
     case Actions.CANCEL_CREATE_OR_RESTORE_ACCOUNT:
       return {
         ...state,
         choseToRestoreAccount: false,
+        recoveringFromStoreWipe: false,
         pincodeType: PincodeType.Unset,
         isSettingPin: false,
       }

--- a/packages/mobile/src/account/reducer.ts
+++ b/packages/mobile/src/account/reducer.ts
@@ -30,7 +30,8 @@ export interface State {
   acceptedTerms: boolean
   hasMigratedToNewBip39: boolean
   choseToRestoreAccount: boolean | undefined
-  recoveringFromStoreWipe: boolean
+  recoveringFromStoreWipe: boolean | undefined
+  accountToRecoverFromStoreWipe: string | undefined
   dailyLimitCusd: number
 }
 
@@ -70,6 +71,7 @@ export const initialState = {
   hasMigratedToNewBip39: false,
   choseToRestoreAccount: false,
   recoveringFromStoreWipe: false,
+  accountToRecoverFromStoreWipe: undefined,
   dailyLimitCusd: DEFAULT_DAILY_PAYMENT_LIMIT_CUSD,
 }
 
@@ -103,6 +105,7 @@ export const reducer = (
         ...state,
         choseToRestoreAccount: true,
         recoveringFromStoreWipe: true,
+        accountToRecoverFromStoreWipe: action.accountToRecover,
         pincodeType: PincodeType.CustomPin,
         acceptedTerms: true,
       }

--- a/packages/mobile/src/account/saga.ts
+++ b/packages/mobile/src/account/saga.ts
@@ -44,19 +44,21 @@ export function* setPincode({ pincodeType }: SetPincodeAction) {
   }
 }
 
-function* clearStoredAccountSaga({ account }: ClearStoredAccountAction) {
+function* clearStoredAccountSaga({ account, softDelete }: ClearStoredAccountAction) {
   try {
-    yield call(removeAccountLocally, account)
-    yield call(clearStoredMnemonic)
-    yield call(ValoraAnalytics.reset)
-    yield call(deleteNodeData)
+    if (!softDelete) {
+      yield call(removeAccountLocally, account)
+      yield call(clearStoredMnemonic)
+      yield call(ValoraAnalytics.reset)
+      yield call(deleteNodeData)
 
-    // Ignore error if it was caused by Firebase.
-    try {
-      yield call(firebaseSignOut, firebase.app())
-    } catch (error) {
-      if (FIREBASE_ENABLED) {
-        Logger.error(TAG + '@clearStoredAccount', 'Failed to sign out from Firebase', error)
+      // Ignore error if it was caused by Firebase.
+      try {
+        yield call(firebaseSignOut, firebase.app())
+      } catch (error) {
+        if (FIREBASE_ENABLED) {
+          Logger.error(TAG + '@clearStoredAccount', 'Failed to sign out from Firebase', error)
+        }
       }
     }
 

--- a/packages/mobile/src/account/saga.ts
+++ b/packages/mobile/src/account/saga.ts
@@ -44,9 +44,9 @@ export function* setPincode({ pincodeType }: SetPincodeAction) {
   }
 }
 
-function* clearStoredAccountSaga({ account, softDelete }: ClearStoredAccountAction) {
+function* clearStoredAccountSaga({ account, onlyReduxState }: ClearStoredAccountAction) {
   try {
-    if (!softDelete) {
+    if (!onlyReduxState) {
       yield call(removeAccountLocally, account)
       yield call(clearStoredMnemonic)
       yield call(ValoraAnalytics.reset)

--- a/packages/mobile/src/account/selectors.ts
+++ b/packages/mobile/src/account/selectors.ts
@@ -13,4 +13,6 @@ export const pincodeTypeSelector = (state: RootState) => state.account.pincodeTy
 export const promptFornoIfNeededSelector = (state: RootState) => state.account.promptFornoIfNeeded
 export const cUsdDailyLimitSelector = (state: RootState) => state.account.dailyLimitCusd
 export const recoveringFromStoreWipeSelector = (state: RootState) =>
-  state.account.recoveringFromStoreWipe
+  state.account.recoveringFromStoreWipe ?? false
+export const accountToRecoverSelector = (state: RootState) =>
+  state.account.accountToRecoverFromStoreWipe

--- a/packages/mobile/src/account/selectors.ts
+++ b/packages/mobile/src/account/selectors.ts
@@ -12,3 +12,5 @@ export const userContactDetailsSelector = (state: RootState) => state.account.co
 export const pincodeTypeSelector = (state: RootState) => state.account.pincodeType
 export const promptFornoIfNeededSelector = (state: RootState) => state.account.promptFornoIfNeeded
 export const cUsdDailyLimitSelector = (state: RootState) => state.account.dailyLimitCusd
+export const recoveringFromStoreWipeSelector = (state: RootState) =>
+  state.account.recoveringFromStoreWipe

--- a/packages/mobile/src/analytics/Events.tsx
+++ b/packages/mobile/src/analytics/Events.tsx
@@ -10,6 +10,7 @@ export enum AppEvents {
   fetch_balance = 'fetch_balance',
   fetch_balance_error = 'fetch_balance_error',
   redux_keychain_mismatch = 'redux_keychain_mismatch',
+  redux_store_recovery_success = 'redux_store_recovery_success',
 }
 
 export enum HomeEvents {

--- a/packages/mobile/src/analytics/Properties.tsx
+++ b/packages/mobile/src/analytics/Properties.tsx
@@ -63,6 +63,9 @@ interface AppEventsProperties {
   [AppEvents.redux_keychain_mismatch]: {
     account: string
   }
+  [AppEvents.redux_store_recovery_success]: {
+    account: string
+  }
 }
 
 interface HomeEventsProperties {

--- a/packages/mobile/src/import/ImportWallet.test.tsx
+++ b/packages/mobile/src/import/ImportWallet.test.tsx
@@ -37,6 +37,7 @@ describe('ImportWallet', () => {
           isImportingWallet={false}
           connected={true}
           isRecoveringFromStoreWipe={false}
+          accountToRecoverFromStoreWipe={undefined}
           {...mockScreenProps}
           {...getMockI18nProps()}
         />

--- a/packages/mobile/src/import/ImportWallet.test.tsx
+++ b/packages/mobile/src/import/ImportWallet.test.tsx
@@ -36,6 +36,7 @@ describe('ImportWallet', () => {
           hideAlert={jest.fn()}
           isImportingWallet={false}
           connected={true}
+          isRecoveringFromStoreWipe={false}
           {...mockScreenProps}
           {...getMockI18nProps()}
         />

--- a/packages/mobile/src/import/saga.test.ts
+++ b/packages/mobile/src/import/saga.test.ts
@@ -3,6 +3,7 @@ import { expectSaga } from 'redux-saga-test-plan'
 import * as matchers from 'redux-saga-test-plan/matchers'
 import { call, select } from 'redux-saga/effects'
 import { setBackupCompleted } from 'src/account/actions'
+import { recoveringFromStoreWipeSelector } from 'src/account/selectors'
 import { showError } from 'src/alert/actions'
 import { ErrorMessages } from 'src/app/ErrorMessages'
 import { currentLanguageSelector } from 'src/app/reducers'
@@ -31,6 +32,7 @@ describe('Import wallet saga', () => {
         [matchers.call.fn(fetchTokenBalanceInWeiWithRetry), new BigNumber(10)],
         [matchers.call.fn(assignAccountFromPrivateKey), mockAccount],
         [call(storeMnemonic, phrase, mockAccount), true],
+        [select(recoveringFromStoreWipeSelector), false],
       ])
       .put(setBackupCompleted())
       .put(redeemInviteSuccess())

--- a/packages/mobile/src/import/saga.ts
+++ b/packages/mobile/src/import/saga.ts
@@ -6,9 +6,12 @@ import {
 import { privateKeyToAddress } from '@celo/utils/lib/address'
 import BigNumber from 'bignumber.js'
 import * as bip39 from 'react-native-bip39'
-import { call, put, spawn, takeLeading } from 'redux-saga/effects'
+import { call, put, select, spawn, takeLeading } from 'redux-saga/effects'
 import { setBackupCompleted } from 'src/account/actions'
+import { recoveringFromStoreWipeSelector } from 'src/account/selectors'
 import { showError } from 'src/alert/actions'
+import { AppEvents } from 'src/analytics/Events'
+import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import { ErrorMessages } from 'src/app/ErrorMessages'
 import { storeMnemonic } from 'src/backup/utils'
 import { CURRENCY_ENUM } from 'src/geth/consts'
@@ -81,6 +84,11 @@ export function* importBackupPhraseSaga({ phrase, useEmptyWallet }: ImportBackup
     // Set redeem invite complete so user isn't brought back into nux flow
     yield put(redeemInviteSuccess())
     yield put(refreshAllBalances())
+
+    const recoveringFromStoreWipe = yield select(recoveringFromStoreWipeSelector)
+    if (recoveringFromStoreWipe) {
+      ValoraAnalytics.track(AppEvents.redux_store_recovery_success, { account })
+    }
 
     navigateClearingStack(Screens.VerificationEducationScreen)
 

--- a/packages/mobile/src/navigator/Navigator.tsx
+++ b/packages/mobile/src/navigator/Navigator.tsx
@@ -9,6 +9,7 @@ import GoldEducation from 'src/account/GoldEducation'
 import Licenses from 'src/account/Licenses'
 import Profile from 'src/account/Profile'
 import { PincodeType } from 'src/account/reducer'
+import StoreWipeRecoveryScreen from 'src/account/StoreWipeRecoveryScreen'
 import SupportContact from 'src/account/SupportContact'
 import { CeloExchangeEvents } from 'src/analytics/Events'
 import AppLoading from 'src/app/AppLoading'
@@ -406,6 +407,11 @@ const backupScreens = (Navigator: typeof Stack) => (
       options={navOptionsForQuiz}
     />
     <Navigator.Screen name={Screens.BackupComplete} component={BackupComplete} options={noHeader} />
+    <Navigator.Screen
+      name={Screens.StoreWipeRecoveryScreen}
+      component={StoreWipeRecoveryScreen}
+      options={StoreWipeRecoveryScreen.navOptions}
+    />
   </>
 )
 

--- a/packages/mobile/src/navigator/Screens.tsx
+++ b/packages/mobile/src/navigator/Screens.tsx
@@ -62,6 +62,7 @@ export enum Screens {
   Settings = 'Settings',
   Simplex = 'Simplex',
   Spend = 'Spend',
+  StoreWipeRecoveryScreen = 'StoreWipeRecoveryScreen',
   Support = 'Support',
   SupportContact = 'SupportContact',
   Sync = 'Sync',

--- a/packages/mobile/src/navigator/types.tsx
+++ b/packages/mobile/src/navigator/types.tsx
@@ -167,6 +167,7 @@ export type StackParamList = {
     withVerification?: boolean
     onSuccess: (pin: string) => void
     onCancel: () => void
+    account?: string
   }
   [Screens.PincodeSet]: { isVerifying: boolean } | undefined
   [Screens.PhoneNumberLookupQuota]: {
@@ -211,6 +212,7 @@ export type StackParamList = {
     | { promptFornoModal?: boolean; promptConfirmRemovalModal?: boolean }
     | undefined
   [Screens.Spend]: undefined
+  [Screens.StoreWipeRecoveryScreen]: { account: string }
   [Screens.Support]: undefined
   [Screens.SupportContact]:
     | {

--- a/packages/mobile/src/onboarding/registration/NameAndPicture.tsx
+++ b/packages/mobile/src/onboarding/registration/NameAndPicture.tsx
@@ -9,6 +9,7 @@ import { ScrollView, StyleSheet } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { useDispatch } from 'react-redux'
 import { setName, setPicture, setPromptForno } from 'src/account/actions'
+import { recoveringFromStoreWipeSelector } from 'src/account/selectors'
 import { hideAlert, showError } from 'src/alert/actions'
 import { OnboardingEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
@@ -30,6 +31,7 @@ function NameAndPicture({ navigation }: Props) {
   const cachedName = useTypedSelector((state) => state.account.name)
   const picture = useTypedSelector((state) => state.account.pictureUri)
   const choseToRestoreAccount = useTypedSelector((state) => state.account.choseToRestoreAccount)
+  const recoveringFromStoreWipe = useTypedSelector(recoveringFromStoreWipeSelector)
   const dispatch = useDispatch()
 
   const { t } = useTranslation(Namespaces.nuxNamePin1)
@@ -48,7 +50,11 @@ function NameAndPicture({ navigation }: Props) {
   }, [navigation, choseToRestoreAccount])
 
   const goToNextScreen = () => {
-    navigate(Screens.PincodeSet)
+    if (recoveringFromStoreWipe) {
+      navigate(Screens.ImportWallet)
+    } else {
+      navigate(Screens.PincodeSet)
+    }
   }
 
   const onPressContinue = () => {

--- a/packages/mobile/src/pincode/PincodeEnter.tsx
+++ b/packages/mobile/src/pincode/PincodeEnter.tsx
@@ -75,8 +75,9 @@ class PincodeEnter extends React.Component<Props, State> {
     const { route, currentAccount } = this.props
     const { pin } = this.state
     const withVerification = route.params.withVerification
-    if (withVerification && currentAccount) {
-      if (await checkPin(pin, currentAccount)) {
+    const account = currentAccount ?? route.params.account
+    if (withVerification && account) {
+      if (await checkPin(pin, account)) {
         this.onCorrectPin(pin)
       } else {
         this.onWrongPin()

--- a/packages/mobile/src/pincode/authentication.ts
+++ b/packages/mobile/src/pincode/authentication.ts
@@ -206,12 +206,17 @@ export async function getPincode(withVerification = true) {
 }
 
 // Navigate to the pincode enter screen and check pin
-export async function requestPincodeInput(withVerification = true, shouldNavigateBack = true) {
+export async function requestPincodeInput(
+  withVerification = true,
+  shouldNavigateBack = true,
+  account?: string
+) {
   const pin = await new Promise((resolve: PinCallback, reject: (error: string) => void) => {
     navigate(Screens.PincodeEnter, {
       onSuccess: resolve,
       onCancel: () => reject(CANCELLED_PIN_INPUT),
       withVerification,
+      account,
     })
   })
 

--- a/packages/mobile/src/utils/accountChecker.ts
+++ b/packages/mobile/src/utils/accountChecker.ts
@@ -2,6 +2,8 @@ import { UnlockableWallet } from '@celo/wallet-base'
 import { call, select } from 'redux-saga/effects'
 import { AppEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
+import { navigateClearingStack } from 'src/navigator/NavigationService'
+import { Screens } from 'src/navigator/Screens'
 import { getWallet } from 'src/web3/contracts'
 import { currentAccountSelector } from 'src/web3/selectors'
 
@@ -13,9 +15,10 @@ export function* checkAccountExistenceSaga() {
   const gethAccounts: string[] = yield wallet.getAccounts()
   const reduxAddress: string = yield select(currentAccountSelector)
   if (!reduxAddress && gethAccounts.length > 0) {
-    // TODO: Try to recover access to the account.
+    const account = gethAccounts[0]
     ValoraAnalytics.track(AppEvents.redux_keychain_mismatch, {
-      account: gethAccounts[0],
+      account,
     })
+    navigateClearingStack(Screens.StoreWipeRecoveryScreen, { account })
   }
 }

--- a/packages/mobile/test/schemas.ts
+++ b/packages/mobile/test/schemas.ts
@@ -540,6 +540,7 @@ export const v8Schema = {
   account: {
     ...v7Schema.account,
     recoveringFromStoreWipe: false,
+    accountToRecoverFromStoreWipe: undefined,
   },
 }
 

--- a/packages/mobile/test/schemas.ts
+++ b/packages/mobile/test/schemas.ts
@@ -537,6 +537,10 @@ export const v8Schema = {
     withoutRevealing: false,
     TEMPORARY_override_withoutVerification: undefined,
   },
+  account: {
+    ...v7Schema.account,
+    recoveringFromStoreWipe: false,
+  },
 }
 
 export function getLatestSchema(): Partial<RootState> {


### PR DESCRIPTION
### Description

When we detect that there is no account stored on the Redux store but there is one on the geth wallet, it means that the Redux store was unexpectedly wiped. To recover from this situation, this PR adds a new screen notifying the user that there's been a user and letting them know that they'll need to input their name and phone number again.

We'll be able to skip the name step in the future when CIP-8 lands.

https://user-images.githubusercontent.com/6062888/113381557-a6826a00-9355-11eb-8291-3d983c9b5b6f.mov

### Other changes

- Added an option to the hidden dev settings to erase the Redux store in order to be able to test this.

### Tested

Manually using the hidden dev setting.

### Related issues

- Fixes #189

### Backwards compatibility

N/A


