### PR TITLE
Choose language before starting recovery flow

### DIFF
--- a/packages/mobile/src/account/StoreWipeRecoveryScreen.tsx
+++ b/packages/mobile/src/account/StoreWipeRecoveryScreen.tsx
@@ -52,7 +52,7 @@ function StoreWipeRecoveryScreen({ route }: Props) {
 
 StoreWipeRecoveryScreen.navOptions = {
   ...emptyHeader,
-  headerLeft: null,
+  headerLeft: () => null,
 }
 
 const styles = StyleSheet.create({

--- a/packages/mobile/src/account/StoreWipeRecoveryScreen.tsx
+++ b/packages/mobile/src/account/StoreWipeRecoveryScreen.tsx
@@ -15,6 +15,7 @@ import { Screens } from 'src/navigator/Screens'
 import { StackParamList } from 'src/navigator/types'
 import { requestPincodeInput } from 'src/pincode/authentication'
 import Logger from 'src/utils/Logger'
+import { getWalletAsync } from 'src/web3/contracts'
 
 type Props = StackScreenProps<StackParamList, Screens.StoreWipeRecoveryScreen>
 
@@ -26,7 +27,8 @@ function StoreWipeRecoveryScreen({ route }: Props) {
 
   const goToOnboarding = async () => {
     try {
-      const account = route.params.account
+      const wallet = await getWalletAsync()
+      const account = wallet.getAccounts()[0]
       await requestPincodeInput(true, false, account)
       dispatch(startStoreWipeRecovery(account))
       navigate(Screens.NameAndPicture)
@@ -50,6 +52,7 @@ function StoreWipeRecoveryScreen({ route }: Props) {
 
 StoreWipeRecoveryScreen.navOptions = {
   ...emptyHeader,
+  headerLeft: null,
 }
 
 const styles = StyleSheet.create({

--- a/packages/mobile/src/account/StoreWipeRecoveryScreen.tsx
+++ b/packages/mobile/src/account/StoreWipeRecoveryScreen.tsx
@@ -9,7 +9,7 @@ import { SafeAreaView } from 'react-native-safe-area-context'
 import { useDispatch } from 'react-redux'
 import { startStoreWipeRecovery } from 'src/account/actions'
 import { Namespaces } from 'src/i18n'
-import { emptyHeader } from 'src/navigator/Headers'
+import { noHeaderGestureDisabled } from 'src/navigator/Headers'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { StackParamList } from 'src/navigator/types'
@@ -50,10 +50,7 @@ function StoreWipeRecoveryScreen({ route }: Props) {
   )
 }
 
-StoreWipeRecoveryScreen.navOptions = {
-  ...emptyHeader,
-  headerLeft: () => null,
-}
+StoreWipeRecoveryScreen.navOptions = noHeaderGestureDisabled
 
 const styles = StyleSheet.create({
   container: {

--- a/packages/mobile/src/navigator/types.tsx
+++ b/packages/mobile/src/navigator/types.tsx
@@ -212,7 +212,7 @@ export type StackParamList = {
     | { promptFornoModal?: boolean; promptConfirmRemovalModal?: boolean }
     | undefined
   [Screens.Spend]: undefined
-  [Screens.StoreWipeRecoveryScreen]: { account: string }
+  [Screens.StoreWipeRecoveryScreen]: undefined
   [Screens.Support]: undefined
   [Screens.SupportContact]:
     | {

--- a/packages/mobile/src/utils/accountChecker.ts
+++ b/packages/mobile/src/utils/accountChecker.ts
@@ -2,6 +2,7 @@ import { UnlockableWallet } from '@celo/wallet-base'
 import { call, select } from 'redux-saga/effects'
 import { AppEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
+import { currentLanguageSelector } from 'src/app/reducers'
 import { navigateClearingStack } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import { getWallet } from 'src/web3/contracts'
@@ -19,6 +20,11 @@ export function* checkAccountExistenceSaga() {
     ValoraAnalytics.track(AppEvents.redux_keychain_mismatch, {
       account,
     })
-    navigateClearingStack(Screens.StoreWipeRecoveryScreen, { account })
+    const language: string | undefined = yield select(currentLanguageSelector)
+    if (!language) {
+      navigateClearingStack(Screens.Language, { nextScreen: Screens.StoreWipeRecoveryScreen })
+    } else {
+      navigateClearingStack(Screens.StoreWipeRecoveryScreen)
+    }
   }
 }

--- a/packages/mobile/src/utils/contentTranslations.ts
+++ b/packages/mobile/src/utils/contentTranslations.ts
@@ -1,7 +1,7 @@
 import i18n from 'src/i18n'
 
 export const getContentForCurrentLang = (content: { [lang: string]: any }) => {
-  const language = i18n.language.toLowerCase()
+  const language = i18n.language?.toLowerCase() ?? 'en'
   const texts = content[language] || content[language.slice(0, 2)] || content.en
   for (const key of Object.keys(texts)) {
     if (typeof texts[key] === 'string') {


### PR DESCRIPTION
### Description

There was an error caused by the language not being reset after the store wipe recovery flow. This PR redirects the user to the language selection screen if we can't autodetect the language when on the store wipe recovery flow.

### Tested

Manually

### Related issues

- Fixes #189

### Backwards compatibility

N/A