### PR TITLE
Fix analytics `drawer_navigation` event

### DIFF
--- a/packages/mobile/src/navigator/DrawerNavigator.tsx
+++ b/packages/mobile/src/navigator/DrawerNavigator.tsx
@@ -95,7 +95,7 @@ function CustomDrawerItemList({
     const { title, drawerLabel, drawerIcon } = descriptors[route.key].options
     const navigateToItem = () => {
       ValoraAnalytics.track(HomeEvents.drawer_navigation, {
-        navigateTo: title || route.name,
+        navigateTo: route.name,
       })
       navigation.dispatch({
         ...(focused ? DrawerActions.closeDrawer() : CommonActions.navigate(route.name)),


### PR DESCRIPTION
### Description

Analytics event `drawer_navigation` was using a localized value for `navigateTo` which made analysis difficult.
It's now using the actual programmatic screen name.

### Tested

Yes

### Related issues

- Fixes https://github.com/celo-org/celo-monorepo/issues/7651

### Backwards compatibility

No, might break existing reporting.