### PR TITLE
Force y18n version 5.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,6 +111,6 @@
     "node-forge": "^0.10.0",
     "web3-eth-contract": "1.3.0",
     "react-native-flipper": "^0.70.0",
-    "y18n": "5.0.5"
+    "y18n": "^5.0.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "object-path": "^0.11.5",
     "node-forge": "^0.10.0",
     "web3-eth-contract": "1.3.0",
-    "react-native-flipper": "^0.70.0"
+    "react-native-flipper": "^0.70.0",
+    "y18n": "5.0.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -111,6 +111,6 @@
     "node-forge": "^0.10.0",
     "web3-eth-contract": "1.3.0",
     "react-native-flipper": "^0.70.0",
-    "y18n": "^5.0.5"
+    "y18n": "5.0.5"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -26362,17 +26362,7 @@ xtend@~2.1.1:
   dependencies:
     object-keys "~0.4.0"
 
-y18n@^3.2.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"
-  integrity sha1-bRX7qITAhnnA136I53WegR4H+kE=
-
-"y18n@^3.2.1 || ^4.0.0", y18n@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
-  integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
-
-y18n@^5.0.5:
+y18n@5.0.5, y18n@^3.2.1, "y18n@^3.2.1 || ^4.0.0", y18n@^4.0.0, y18n@^5.0.5:
   version "5.0.5"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.5.tgz#8769ec08d03b1ea2df2500acef561743bbb9ab18"
   integrity sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==


### PR DESCRIPTION
### Description

A new vulnerability was published recently in the y18n package: https://www.npmjs.com/advisories/1654

I tried in PR https://github.com/celo-org/wallet/pull/177 to upgrade the packages that are using the old version of y18n but it quickly went out of control to the point where the codegen library would break other parts of the code. I've spent some time trying to upgrade everything except for the codegen lib (which is needed in the notification service) but the change became really messy. So, I decided to just use the force resolution mechanism for now.

### Other changes

None

### Tested

Build and run tests locally.

### Related issues

- Fixes #174 

### Backwards compatibility

Yes.
