### PR TITLE
Fix the fetching of exchange rates

### DIFF
--- a/packages/mobile/src/exchange/reducer.ts
+++ b/packages/mobile/src/exchange/reducer.ts
@@ -3,7 +3,7 @@ import { Actions, ActionTypes } from 'src/exchange/actions'
 import { getRehydratePayload, REHYDRATE, RehydrateAction } from 'src/redux/persist-helper'
 import { RootState } from 'src/redux/reducers'
 
-export const MAX_HISTORY_RETENTION = 30 * 24 * 3600 * 1000 // (ms) ~ 180 days
+export const MAX_HISTORY_RETENTION = 30 * 24 * 3600 * 1000 // (ms) ~ 30 days
 export const ADDRESS_LENGTH = 42
 
 export interface ExchangeRatePair {

--- a/packages/mobile/src/firebase/saga.ts
+++ b/packages/mobile/src/firebase/saga.ts
@@ -107,11 +107,8 @@ function celoGoldExchangeRateHistoryChannel(lastTimeUpdated: number) {
     const singleItemEmitter = (snapshot: FirebaseDatabaseTypes.DataSnapshot) => {
       emit([snapshot.val()])
     }
-    let cancelFunction = () => {
-      return
-    }
     const listenForNewElements = (newElementsStartAt: number) => {
-      cancelFunction = firebase
+      firebase
         .database()
         .ref(`${EXCHANGE_RATES}/cGLD/cUSD`)
         .orderByChild('timestamp')
@@ -142,7 +139,12 @@ function celoGoldExchangeRateHistoryChannel(lastTimeUpdated: number) {
         Logger.error(TAG, 'Error while fetching exchange rates', error)
       })
 
-    return cancelFunction
+    return () => {
+      firebase
+        .database()
+        .ref(`${EXCHANGE_RATES}/cGLD/cUSD`)
+        .off()
+    }
   })
 }
 

--- a/packages/mobile/src/firebase/saga.ts
+++ b/packages/mobile/src/firebase/saga.ts
@@ -107,7 +107,9 @@ function celoGoldExchangeRateHistoryChannel(lastTimeUpdated: number) {
     const singleItemEmitter = (snapshot: FirebaseDatabaseTypes.DataSnapshot) => {
       emit([snapshot.val()])
     }
-    let cancelFunction = () => {}
+    let cancelFunction = () => {
+      return
+    }
     const listenForNewElements = (newElementsStartAt: number) => {
       cancelFunction = firebase
         .database()
@@ -136,6 +138,9 @@ function celoGoldExchangeRateHistoryChannel(lastTimeUpdated: number) {
       .orderByChild('timestamp')
       .startAt(startAt)
       .once(VALUE_CHANGE_HOOK, fullListEmitter, errorCallback)
+      .catch((error) => {
+        Logger.error(TAG, 'Error while fetching exchange rates', error)
+      })
 
     return cancelFunction
   })

--- a/packages/mobile/src/redux/migrations.test.ts
+++ b/packages/mobile/src/redux/migrations.test.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_DAILY_PAYMENT_LIMIT_CUSD } from 'src/config'
+import { initialState as exchangeInitialState } from 'src/exchange/reducer'
 import { CicoProviderNames } from 'src/fiatExchanges/reducer'
 import { migrations } from 'src/redux/migrations'
 import { v0Schema, v1Schema, v2Schema, v7Schema, v8Schema, vNeg1Schema } from 'test/schemas'
@@ -176,5 +177,26 @@ describe('Redux persist migrations', () => {
     expect(migratedSchema.app.kotaniEnabled).toBeUndefined()
     expect(migratedSchema.app.bitfyUrl).toBeUndefined()
     expect(migratedSchema.app.flowBtcUrl).toBeUndefined()
+  })
+  it('works for v11 to v12', () => {
+    const appStub = 'dont delete please'
+    const exchangeStub = 'also dont delete please'
+    const stub = {
+      exchange: {
+        otherExchangeProps: exchangeStub,
+        history: {
+          celoGoldExchangeRates: [1, 2, 3],
+          aggregatedExchangeRates: [4, 5, 6],
+          granularity: 0,
+          range: 0,
+          lastTimeUpdated: 100,
+        },
+      },
+      app: appStub,
+    }
+    const migratedSchema = migrations[12](stub)
+    expect(migratedSchema.app).toEqual(appStub)
+    expect(migratedSchema.exchange.otherExchangeProps).toEqual(exchangeStub)
+    expect(migratedSchema.exchange.history).toEqual(exchangeInitialState.history)
   })
 })

--- a/packages/mobile/src/redux/migrations.ts
+++ b/packages/mobile/src/redux/migrations.ts
@@ -1,5 +1,6 @@
 import _ from 'lodash'
 import { DEFAULT_DAILY_PAYMENT_LIMIT_CUSD } from 'src/config'
+import { initialState as exchangeInitialState } from 'src/exchange/reducer'
 import { providersDisplayInfo } from 'src/fiatExchanges/reducer'
 import { AddressToDisplayNameType } from 'src/identity/reducer'
 
@@ -164,6 +165,16 @@ export const migrations = {
     return {
       ...state,
       app: _.omit(state.app, 'pontoEnabled', 'kotaniEnabled', 'bitfyUrl', 'flowBtcUrl'),
+    }
+  },
+  12: (state: any) => {
+    // Removing the exchange rate history because it's very likely that it's repeated a bunch of times.
+    return {
+      ...state,
+      exchange: {
+        ...state.exchange,
+        history: { ...exchangeInitialState.history },
+      },
     }
   },
 }

--- a/packages/mobile/src/redux/store.ts
+++ b/packages/mobile/src/redux/store.ts
@@ -18,7 +18,7 @@ let lastEventTime = Date.now()
 
 const persistConfig: any = {
   key: 'root',
-  version: 11, // default is -1, increment as we make migrations
+  version: 12, // default is -1, increment as we make migrations
   keyPrefix: `reduxStore-`, // the redux-persist default is `persist:` which doesn't work with some file systems.
   storage: FSStorage(),
   blacklist: ['geth', 'networkInfo', 'alert', 'fees', 'recipients', 'imports'],


### PR DESCRIPTION
### Description

We had a bug in the fetching of the exchange rates that made us fetch the whole thing every time there was an update, which is every 30 minutes. The number of elements to fetch each time depended on how much time it passed since the last use of the app, for new users and for users that didn't open the app in a couple months we would load all the history for three months.

We were also fetching the whole exchange rate history from Firebase and filtering it in memory instead of only fetching the latest three months. We tried to filter, but we were sending `1` as `startAt` which returns everything.

With the current changes, we load everything since the max between the last update and three months ago and then we listen only for new items, we don't reload everything again.

### Other changes

- Added a migration to delete the exchange rate history from Redux since it was likely that it was repeated a bunch of times.

### Tested

Mostly manually, by making changes and adding and modifying items in the RTDB to see that the behavior was the expected one.

### Related issues

- Fixes https://github.com/celo-org/celo-monorepo/issues/6284

### Backwards compatibility

N/A