### PR TITLE
Fix sending of "invite received" notification

### DIFF
--- a/packages/notification-service/src/config.ts
+++ b/packages/notification-service/src/config.ts
@@ -44,6 +44,7 @@ export const WEB3_PROVIDER_URL = process.env.WEB3_PROVIDER_URL || 'UNDEFINED'
 export enum NotificationTypes {
   PAYMENT_RECEIVED = 'PAYMENT_RECEIVED',
   PAYMENT_REQUESTED = 'PAYMENT_REQUESTED',
+  INVITE_REDEEMED = 'INVITE_REDEEMED',
 }
 
 const en = require('../locales/en.json')

--- a/packages/notification-service/src/firebase.ts
+++ b/packages/notification-service/src/firebase.ts
@@ -345,7 +345,9 @@ export async function requestedPaymentNotification(uid: string, data: PaymentReq
 
 export async function sendInviteNotification(inviter: string) {
   const t = getTranslatorForAddress(inviter)
-  return sendNotification(t('inviteTitle'), t('inviteBody'), inviter, {})
+  return sendNotification(t('inviteTitle'), t('inviteBody'), inviter, {
+    type: NotificationTypes.INVITE_REDEEMED,
+  })
 }
 
 export async function sendNotification(
@@ -385,7 +387,9 @@ export async function sendNotification(
 
     // Notification metrics
     metrics.sentNotification(data.type)
-    metrics.setNotificationLatency(Date.now() - Number(data.timestamp), data.type)
+    if (data.timestamp) {
+      metrics.setNotificationLatency(Date.now() - Number(data.timestamp), data.type)
+    }
   } catch (error) {
     console.error('Error sending notification:', address, error)
     metrics.failedNotification(data.type)

--- a/packages/notification-service/src/invites/invites.ts
+++ b/packages/notification-service/src/invites/invites.ts
@@ -8,25 +8,16 @@ import { getContractKit } from '../util/utils'
 
 const TAG = 'INVITES'
 
-let sendingInvites = false
-
 function updateLastInviteBlock(fromBlock: number, events: EventLog[]) {
   if (events.length === 0) {
     return
   }
-  const maxBlock = events
-    .map((event) => event.blockNumber)
-    .reduce((max, current) => Math.max(max, current), fromBlock)
+  const maxBlock = events.reduce((max, event) => Math.max(max, event.blockNumber), fromBlock)
   setLastInviteBlockNotified(maxBlock)
 }
 
 export async function handleInvites() {
   try {
-    if (sendingInvites) {
-      return
-    }
-    sendingInvites = true
-
     const kit = await getContractKit()
     const fromBlock = getLastInviteBlockNotified() + 1
     if (fromBlock <= 0) {
@@ -48,7 +39,5 @@ export async function handleInvites() {
     }
   } catch (error) {
     console.error(TAG, 'Error while sending invite notifications', error)
-  } finally {
-    sendingInvites = false
   }
 }

--- a/packages/notification-service/src/invites/invites.ts
+++ b/packages/notification-service/src/invites/invites.ts
@@ -1,3 +1,4 @@
+import { EventLog } from 'web3-core'
 import {
   getLastInviteBlockNotified,
   sendInviteNotification,
@@ -7,27 +8,47 @@ import { getContractKit } from '../util/utils'
 
 const TAG = 'INVITES'
 
-export async function handleInvites() {
-  const kit = await getContractKit()
-  const fromBlock = getLastInviteBlockNotified() + 1
-  if (fromBlock <= 0) {
+let sendingInvites = false
+
+function updateLastInviteBlock(fromBlock: number, events: EventLog[]) {
+  if (events.length === 0) {
     return
   }
-  console.debug(TAG, `Starting to fetch invites from block ${fromBlock}`)
+  const maxBlock = events
+    .map((event) => event.blockNumber)
+    .reduce((max, current) => Math.max(max, current), fromBlock)
+  setLastInviteBlockNotified(maxBlock)
+}
 
-  const escrow = await kit.contracts.getEscrow()
-  const events = await escrow.getPastEvents('Withdrawal', {
-    fromBlock,
-  })
-  console.debug(TAG, `Got ${events.length} escrow withdrawal events`)
-  let maxBlock = fromBlock
-  for (const event of events) {
-    maxBlock = Math.max(event.blockNumber, fromBlock)
-    const inviter = event.returnValues.to.toLowerCase()
-    console.debug(TAG, `Sending invite notification to ${inviter}`)
-    await sendInviteNotification(inviter)
-  }
-  if (maxBlock > fromBlock) {
-    setLastInviteBlockNotified(maxBlock)
+export async function handleInvites() {
+  try {
+    if (sendingInvites) {
+      return
+    }
+    sendingInvites = true
+
+    const kit = await getContractKit()
+    const fromBlock = getLastInviteBlockNotified() + 1
+    if (fromBlock <= 0) {
+      return
+    }
+    console.debug(TAG, `Starting to fetch invites from block ${fromBlock}`)
+
+    const escrow = await kit.contracts.getEscrow()
+    const events = await escrow.getPastEvents('Withdrawal', {
+      fromBlock,
+    })
+    updateLastInviteBlock(fromBlock, events)
+    console.debug(TAG, `Got ${events.length} escrow withdrawal events`)
+
+    for (const event of events) {
+      const inviter = event.returnValues.to.toLowerCase()
+      console.debug(TAG, `Sending invite notification to ${inviter}`)
+      await sendInviteNotification(inviter)
+    }
+  } catch (error) {
+    console.error(TAG, 'Error while sending invite notifications', error)
+  } finally {
+    sendingInvites = false
   }
 }

--- a/packages/notification-service/src/polling.ts
+++ b/packages/notification-service/src/polling.ts
@@ -9,7 +9,6 @@ export const notificationPolling = AsyncPolling(async (end) => {
   try {
     await handleTransferNotifications()
     await handlePaymentRequests()
-    await handleInvites()
   } catch (e) {
     console.error('Notifications polling failed', e)
   } finally {


### PR DESCRIPTION
### Description

Some users were receiving a large number of push notifications when someone they invited joined Valora.

The reason is that we were not updating the `lastInviteBlockNotified` correctly if the notified block was the last notified + 1. This issue was introduced recently here: https://github.com/celo-org/wallet/pull/244

### Other changes

Added a `type` for invite redeemed notifications.

### Tested

Manually

### Related issues

- Fixes #278

### Backwards compatibility

N/A