### PR TITLE
Bump `resource_class` to `large` to fix `general-tests` randomly failing with exit code 137

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -374,7 +374,6 @@ jobs:
       - store_test_results:
           path: packages/mobile/e2e/test-results
 
-
   lint-checks:
     <<: *defaults
     steps:
@@ -394,6 +393,7 @@ jobs:
 
   general-tests:
     <<: *defaults
+    resource_class: large
     steps:
       - attach_workspace:
           at: ~/app


### PR DESCRIPTION
### Description

Fix `general-tests` randomly failing on CircleCI with exit code 137.
This happened on `celo-monorepo` too: https://github.com/celo-org/celo-monorepo/commit/d2bcf42cb96c6a23bf08dd9f21dec7948aeb188f

### Tested

`general-tests` is green on CircleCI.

### Backwards compatibility

Yes.