### PR TITLE
[Wallet] Fix incorrect analytics event sent when choosing restore account

### DIFF
--- a/packages/mobile/src/analytics/Events.test.tsx
+++ b/packages/mobile/src/analytics/Events.test.tsx
@@ -1,0 +1,16 @@
+import * as AnalyticsEvents from 'src/analytics/Events'
+
+describe('AnalyticsEvents', () => {
+  it('all events keys should match their values', () => {
+    expect.hasAssertions()
+    const eventsEnums = Object.keys(AnalyticsEvents)
+
+    for (const eventEnumKey of eventsEnums) {
+      const eventEnum = AnalyticsEvents[eventEnumKey]
+
+      for (const [key, value] of Object.entries(eventEnum)) {
+        expect(value).toBe(key)
+      }
+    }
+  })
+})

--- a/packages/mobile/src/analytics/Events.test.tsx
+++ b/packages/mobile/src/analytics/Events.test.tsx
@@ -6,6 +6,7 @@ describe('AnalyticsEvents', () => {
     const eventsEnums = Object.keys(AnalyticsEvents)
 
     for (const eventEnumKey of eventsEnums) {
+      // @ts-ignore
       const eventEnum = AnalyticsEvents[eventEnumKey]
 
       for (const [key, value] of Object.entries(eventEnum)) {

--- a/packages/mobile/src/analytics/Events.tsx
+++ b/packages/mobile/src/analytics/Events.tsx
@@ -49,8 +49,8 @@ export enum OnboardingEvents {
   create_account_start = 'create_account_start',
   create_account_cancel = 'create_account_cancel',
 
-  restore_account_start = 'create_account_start',
-  restore_account_cancel = 'create_account_cancel',
+  restore_account_start = 'restore_account_start',
+  restore_account_cancel = 'restore_account_cancel',
 
   backup_education_start = 'backup_education_start',
   backup_education_scroll = 'backup_education_scroll',


### PR DESCRIPTION
### Description

Fix incorrect analytics event sent when choosing restore account.
See Slack thread: https://celo-org.slack.com/archives/CL7BVQPHB/p1620135124192500

### Tested

Added a test to ensure this won't happen in the future.

### How others should test

On the `Welcome` screen with the `Create` and `Restore` buttons, tapping the `Restore` button should log an analytic event stating `restore_account_start`.

### Backwards compatibility

N/A