### PR TITLE
Fix loading indicator for Simplex checkout page on Android

### DIFF
--- a/packages/mobile/src/fiatExchanges/SimplexScreen.tsx
+++ b/packages/mobile/src/fiatExchanges/SimplexScreen.tsx
@@ -50,7 +50,7 @@ function SimplexScreen({ route, navigation }: Props) {
     simplexQuote.fiat_money.total_amount - simplexQuote.fiat_money.base_amount <= 0
 
   const onNavigationStateChange = ({ url }: any) => {
-    if (url?.endsWith('step=card_details')) {
+    if (url?.includes('/payments/new')) {
       setRedirected(true)
     } else if (url?.startsWith('celo://wallet')) {
       navigateToURI(url)
@@ -102,7 +102,7 @@ function SimplexScreen({ route, navigation }: Props) {
     <View style={styles.container}>
       {loadSimplexCheckout && simplexPaymentRequest && !redirected && (
         <View style={[styles.container, styles.indicator]}>
-          <ActivityIndicator size="large" color={colors.greenUI} />
+          <ActivityIndicator size="large" color={colors.greenBrand} />
         </View>
       )}
       {!loadSimplexCheckout || !simplexPaymentRequest ? (
@@ -168,6 +168,7 @@ const styles = StyleSheet.create({
     left: 0,
     width: '100%',
     height: '100%',
+    zIndex: 1,
   },
   button: {
     margin: 16,


### PR DESCRIPTION
### Description
Fix a bug where the loading indicator for the Simplex Webview was not showing up on Android devices.

### Other changes
N/A

### Tested
Yes


### How others should test
Check that the loading indicator appears on both iOS and Android when the user presses "Continue to Simplex" after selecting Simplex as a cash-out option.

### Related issues
- Fixes #347 

### Backwards compatibility

_Brief explanation of why these changes are/are not backwards compatible._