### PR TITLE
Don't show invites until they can be reclaimed

### DIFF
--- a/packages/mobile/src/config.ts
+++ b/packages/mobile/src/config.ts
@@ -46,7 +46,7 @@ export const DOLLAR_CASH_OUT_MIN_AMOUNT = 0.01
 export const DOLLAR_TRANSACTION_MIN_AMOUNT = 0.01
 export const GOLD_TRANSACTION_MIN_AMOUNT = 0.001
 // The number of seconds before the sender can reclaim the payment.
-export const ESCROW_PAYMENT_EXPIRY_SECONDS = 3600 // 1 hour
+export const ESCROW_PAYMENT_EXPIRY_SECONDS = 1 // The contract doesn't allow 0 seconds.
 export const DEFAULT_TESTNET = Config.DEFAULT_TESTNET
 export const DEFAULT_DAILY_PAYMENT_LIMIT_CUSD = 1000
 export const SMS_RETRIEVER_APP_SIGNATURE = Config.SMS_RETRIEVER_APP_SIGNATURE

--- a/packages/mobile/src/escrow/EscrowedPaymentListScreen.tsx
+++ b/packages/mobile/src/escrow/EscrowedPaymentListScreen.tsx
@@ -4,7 +4,7 @@ import { View } from 'react-native'
 import { connect } from 'react-redux'
 import { EscrowedPayment } from 'src/escrow/actions'
 import EscrowedPaymentListItem from 'src/escrow/EscrowedPaymentListItem'
-import { sentEscrowedPaymentsSelector } from 'src/escrow/reducer'
+import { getReclaimableEscrowPayments } from 'src/escrow/reducer'
 import i18n, { Namespaces, withTranslation } from 'src/i18n'
 import {
   NotificationList,
@@ -19,7 +19,7 @@ interface StateProps {
 
 const mapStateToProps = (state: RootState): StateProps => ({
   dollarBalance: state.stableToken.balance,
-  sentEscrowedPayments: sentEscrowedPaymentsSelector(state),
+  sentEscrowedPayments: getReclaimableEscrowPayments(state),
 })
 
 type Props = WithTranslation & StateProps

--- a/packages/mobile/src/escrow/__mocks__.ts
+++ b/packages/mobile/src/escrow/__mocks__.ts
@@ -9,7 +9,7 @@ const senderAddress = '0x000000000000000000000ce10'
 const currency = SHORT_CURRENCIES.DOLLAR
 
 const date = new BigNumber(
-  new Date('Tue Mar 05 2019 13:44:06 GMT-0800 (Pacific Standard Time)').getTime()
+  new Date('Tue Mar 05 2019 13:44:06 GMT-0800 (Pacific Standard Time)').getTime() / 1000
 )
 
 export function escrowPaymentDouble(partial: object): EscrowedPayment {
@@ -22,7 +22,7 @@ export function escrowPaymentDouble(partial: object): EscrowedPayment {
     amount: multiplyByWei(new BigNumber(7)),
     message: 'test message',
     timestamp: date,
-    expirySeconds: new BigNumber(60),
+    expirySeconds: new BigNumber(0),
     ...partial,
   }
 }

--- a/packages/mobile/src/escrow/reducer.ts
+++ b/packages/mobile/src/escrow/reducer.ts
@@ -1,3 +1,4 @@
+import { createSelector } from 'reselect'
 import { Actions, ActionTypes, EscrowedPayment } from 'src/escrow/actions'
 import { RootState } from 'src/redux/reducers'
 
@@ -44,3 +45,13 @@ export const escrowReducer = (state: State | undefined = initialState, action: A
 }
 
 export const sentEscrowedPaymentsSelector = (state: RootState) => state.escrow.sentEscrowedPayments
+export const getReclaimableEscrowPayments = createSelector(
+  sentEscrowedPaymentsSelector,
+  (sentPayments) => {
+    const currUnixTime = Date.now() / 1000
+    return sentPayments.filter((payment) => {
+      const paymentExpiryTime = +payment.timestamp + +payment.expirySeconds
+      return currUnixTime >= paymentExpiryTime
+    })
+  }
+)

--- a/packages/mobile/src/home/NotificationBox.tsx
+++ b/packages/mobile/src/home/NotificationBox.tsx
@@ -19,7 +19,7 @@ import {
 } from 'src/consumerIncentives/analyticsEventsTracker'
 import { EscrowedPayment } from 'src/escrow/actions'
 import EscrowedPaymentReminderSummaryNotification from 'src/escrow/EscrowedPaymentReminderSummaryNotification'
-import { sentEscrowedPaymentsSelector } from 'src/escrow/reducer'
+import { getReclaimableEscrowPayments } from 'src/escrow/reducer'
 import { pausedFeatures } from 'src/flags'
 import { dismissNotification } from 'src/home/actions'
 import { IdToNotification } from 'src/home/reducers'
@@ -98,7 +98,7 @@ const mapStateToProps = (state: RootState): StateProps => ({
   dismissedGetVerified: state.account.dismissedGetVerified,
   verificationPossible: verificationPossibleSelector(state),
   dismissedGoldEducation: state.account.dismissedGoldEducation,
-  reclaimableEscrowPayments: sentEscrowedPaymentsSelector(state),
+  reclaimableEscrowPayments: getReclaimableEscrowPayments(state),
 })
 
 const mapDispatchToProps = {

--- a/packages/mobile/src/home/selectors.ts
+++ b/packages/mobile/src/home/selectors.ts
@@ -3,7 +3,7 @@ import _ from 'lodash'
 import DeviceInfo from 'react-native-device-info'
 import { createSelector } from 'reselect'
 import { defaultCountryCodeSelector } from 'src/account/selectors'
-import { sentEscrowedPaymentsSelector } from 'src/escrow/reducer'
+import { getReclaimableEscrowPayments } from 'src/escrow/reducer'
 import {
   getIncomingPaymentRequests,
   getOutgoingPaymentRequests,
@@ -17,7 +17,7 @@ export const getActiveNotificationCount = createSelector(
   [
     getIncomingPaymentRequests,
     getOutgoingPaymentRequests,
-    sentEscrowedPaymentsSelector,
+    getReclaimableEscrowPayments,
     (state) => state.account.backupCompleted,
   ],
   (incomingPaymentReqs, outgoingPaymentRequests, reclaimableEscrowPayments, backupCompleted) => {


### PR DESCRIPTION
### Description

In this PR: https://github.com/celo-org/wallet/commit/f0fc5e55a3d10568253a878abb555b7beb76f6b3 we started showing escrow invites as soon as they are sent. However, this brings an issue because it can't be reclaimed immediately, you need to wait at least one hour.

### Other changes

N/A

### Tested

Manually, I invited people and they don't show up on the invite box for one hour.

### How others should test

Invite someone and see that they don't show up in the invite box. After one hour they should appear and the payment must be reclaimable.

### Related issues

- Fixes #350

### Backwards compatibility

N/A