### PR TITLE
Use account address when giving CIP8 profile access

### DIFF
--- a/packages/mobile/src/account/profileInfo.test.ts
+++ b/packages/mobile/src/account/profileInfo.test.ts
@@ -128,7 +128,7 @@ describe(uploadNameAndPicture, () => {
 })
 
 describe(giveProfileAccess, () => {
-  const recipients = [mockAccount2]
+  const recipients = mockAccount2
 
   it('gives profile access successfully', async () => {
     await expectSaga(giveProfileAccess, recipients)

--- a/packages/mobile/src/account/profileInfo.test.ts
+++ b/packages/mobile/src/account/profileInfo.test.ts
@@ -1,3 +1,4 @@
+import { normalizeAddressWith0x } from '@celo/utils/lib/address'
 import RNFS from 'react-native-fs'
 import { expectSaga } from 'redux-saga-test-plan'
 import { call, select } from 'redux-saga/effects'
@@ -10,6 +11,7 @@ import {
   uploadNameAndPicture,
 } from 'src/account/profileInfo'
 import { isProfileUploadedSelector, nameSelector, pictureSelector } from 'src/account/selectors'
+import { walletToAccountAddressSelector } from 'src/identity/reducer'
 import { DEK, retrieveOrGeneratePepper } from 'src/pincode/authentication'
 import { getContractKit, getWallet } from 'src/web3/contracts'
 import { getAccountAddress, getConnectedUnlockedAccount } from 'src/web3/saga'
@@ -128,11 +130,14 @@ describe(uploadNameAndPicture, () => {
 })
 
 describe(giveProfileAccess, () => {
-  const recipients = mockAccount2
+  const walletAddress = mockAccount2
+  const accountAddress = '0xTEST'
+  const walletToAccountAddress = { [normalizeAddressWith0x(walletAddress)]: accountAddress }
 
   it('gives profile access successfully', async () => {
-    await expectSaga(giveProfileAccess, recipients)
+    await expectSaga(giveProfileAccess, walletAddress)
       .provide([
+        [select(walletToAccountAddressSelector), walletToAccountAddress],
         [call(getOffchainWrapper), null],
         [call(getConnectedUnlockedAccount), mockAccount],
         [select(nameSelector), mockName],
@@ -141,14 +146,15 @@ describe(giveProfileAccess, () => {
       ])
       .run()
 
-    expect(mockNameAllowAccess).toBeCalledWith(recipients)
-    expect(mockPictureAllowAccess).toBeCalledWith(recipients)
+    expect(mockNameAllowAccess).toBeCalledWith([accountAddress])
+    expect(mockPictureAllowAccess).toBeCalledWith([accountAddress])
   })
 
   it('handles error when fails to give recipient access to name', async () => {
     mockNameAllowAccess.mockReturnValueOnce(Error('error'))
-    await expectSaga(giveProfileAccess, recipients)
+    await expectSaga(giveProfileAccess, walletAddress)
       .provide([
+        [select(walletToAccountAddressSelector), walletToAccountAddress],
         [call(getOffchainWrapper), null],
         [call(getConnectedUnlockedAccount), mockAccount],
         [select(nameSelector), mockName],
@@ -157,14 +163,15 @@ describe(giveProfileAccess, () => {
       ])
       .run()
       .catch((error) => {
-        expect(error).toEqual(Error(`Unable to give ${recipients} access to name`))
+        expect(error).toEqual(Error(`Unable to give ${walletAddress} access to name`))
       })
   })
 
   it('handles error when fails to give recipient access to picture', async () => {
     mockPictureAllowAccess.mockReturnValueOnce(Error('error'))
-    await expectSaga(giveProfileAccess, recipients)
+    await expectSaga(giveProfileAccess, walletAddress)
       .provide([
+        [select(walletToAccountAddressSelector), walletToAccountAddress],
         [call(getOffchainWrapper), null],
         [call(getConnectedUnlockedAccount), mockAccount],
         [select(nameSelector), mockName],
@@ -173,7 +180,7 @@ describe(giveProfileAccess, () => {
       ])
       .run()
       .catch((error) => {
-        expect(error).toEqual(Error(`Unable to give ${recipients} access to picture`))
+        expect(error).toEqual(Error(`Unable to give ${walletAddress} access to picture`))
       })
   })
 })

--- a/packages/mobile/src/account/profileInfo.ts
+++ b/packages/mobile/src/account/profileInfo.ts
@@ -97,7 +97,8 @@ export function* giveProfileAccess(walletAddress: string) {
     const walletToAccountAddress: WalletToAccountAddressType = yield select(
       walletToAccountAddressSelector
     )
-    const accountAddress = walletToAccountAddress[walletAddress] ?? walletAddress
+    const accountAddress =
+      walletToAccountAddress[normalizeAddressWith0x(walletAddress)] ?? walletAddress
 
     const offchainWrapper: UploadServiceDataWrapper = yield call(getOffchainWrapper)
     const nameAccessor = new PrivateNameAccessor(offchainWrapper)

--- a/packages/mobile/src/account/profileInfo.ts
+++ b/packages/mobile/src/account/profileInfo.ts
@@ -91,17 +91,13 @@ export function* uploadNameAndPicture() {
 }
 
 // this function gives permission to the recipient to view the user's profile info
-export function* giveProfileAccess(recipientAddress: string) {
+export function* giveProfileAccess(walletAddress: string) {
   // TODO: check if key for recipient already exists, skip if yes
   try {
     const walletToAccountAddress: WalletToAccountAddressType = yield select(
       walletToAccountAddressSelector
     )
-    const accountAddress = walletToAccountAddress[recipientAddress]
-    if (!accountAddress) {
-      Logger.info(TAG, 'cannot find account address for wallet address', recipientAddress)
-      return
-    }
+    const accountAddress = walletToAccountAddress[walletAddress] ?? walletAddress
 
     const offchainWrapper: UploadServiceDataWrapper = yield call(getOffchainWrapper)
     const nameAccessor = new PrivateNameAccessor(offchainWrapper)
@@ -120,15 +116,10 @@ export function* giveProfileAccess(recipientAddress: string) {
         return
       }
     }
-    // not throwing error, because possibility the recipient doesn't have a registered DEK
 
     Logger.info(TAG + '@giveProfileAccess', 'uploaded symmetric keys for ' + accountAddress)
   } catch (error) {
-    Logger.error(
-      TAG + '@giveProfileAccess',
-      'error when giving access to ' + recipientAddress,
-      error
-    )
+    Logger.error(TAG + '@giveProfileAccess', 'error when giving access to ' + walletAddress, error)
   }
 }
 

--- a/packages/mobile/src/send/saga.ts
+++ b/packages/mobile/src/send/saga.ts
@@ -188,7 +188,7 @@ function* sendPayment(
       amount: amount.toString(),
       currency,
     })
-    yield call(giveProfileAccess, [recipientAddress])
+    yield call(giveProfileAccess, recipientAddress)
   } catch (error) {
     Logger.error(`${TAG}/sendPayment`, 'Could not send payment', error)
     ValoraAnalytics.track(SendEvents.send_tx_error, { error: error.message })

--- a/packages/mobile/src/web3/dataEncryptionKey.ts
+++ b/packages/mobile/src/web3/dataEncryptionKey.ts
@@ -13,7 +13,12 @@ import { OdisUtils } from '@celo/identity'
 import { AuthSigner } from '@celo/identity/lib/odis/query'
 import { FetchError, TxError } from '@celo/komencikit/src/errors'
 import { KomenciKit } from '@celo/komencikit/src/kit'
-import { ensureLeading0x, eqAddress, hexToBuffer } from '@celo/utils/lib/address'
+import {
+  ensureLeading0x,
+  eqAddress,
+  hexToBuffer,
+  normalizeAddressWith0x,
+} from '@celo/utils/lib/address'
 import { CURRENCY_ENUM } from '@celo/utils/lib/currencies'
 import { compressedPubKey, deriveDek } from '@celo/utils/lib/dataEncryptionKey'
 import * as bip39 from 'react-native-bip39'
@@ -63,7 +68,8 @@ export function* doFetchDataEncryptionKey(walletAddress: string) {
   const walletToAccountAddress: WalletToAccountAddressType = yield select(
     walletToAccountAddressSelector
   )
-  const accountAddress = walletToAccountAddress[walletAddress] ?? walletAddress
+  const accountAddress =
+    walletToAccountAddress[normalizeAddressWith0x(walletAddress)] ?? walletAddress
   const dek: string = yield call(accountsWrapper.getDataEncryptionKey, accountAddress)
   yield put(updateAddressDekMap(accountAddress, dek || null))
   return !dek ? null : hexToBuffer(dek)


### PR DESCRIPTION
### Description

If the account address of the recipient is known, use that address to grant CIP8 profile access


### Tested

not tested

