### PR TITLE
Verification fixes

### DIFF
--- a/packages/mobile/src/identity/securityCode.ts
+++ b/packages/mobile/src/identity/securityCode.ts
@@ -78,15 +78,16 @@ async function requestValidator(
       securityCode,
     }
 
-    return attestationsWrapper.getAttestationForSecurityCode(
+    const attestationCode = await attestationsWrapper.getAttestationForSecurityCode(
       attestation.attestationServiceURL,
       requestBody,
       signer
     )
+    return attestationCode
   } catch (error) {
     Logger.error(
       TAG + '@getAttestationCodeFromSecurityCode',
-      `get for issuer ${issuer} failed`,
+      `get for issuer ${issuer} failed - ${JSON.stringify(error)}`,
       error
     )
     throw error

--- a/packages/mobile/src/identity/verification.ts
+++ b/packages/mobile/src/identity/verification.ts
@@ -918,7 +918,7 @@ function* completeAttestation(
   // to ensure `processingInputCode` has enough time to properly gate the tx. 0-index code
   // will have 0 delay, 1-index code will have 1 sec delay, etc.
   if (shouldUseKomenci) {
-    yield delay(codePosition * 1000)
+    yield delay(codePosition * 3000)
     yield inputAttestationCodeLock.acquireAsync()
     const completeTxResult: Result<CeloTxReceipt, FetchError | TxError> = yield call(
       submitCompleteTxAndRetryOnRevert,

--- a/packages/mobile/src/identity/verification.ts
+++ b/packages/mobile/src/identity/verification.ts
@@ -1100,14 +1100,16 @@ export function* tryRevealPhoneNumber(
       )
     )
 
-    throw new Error(
-      `Error revealing to issuer ${attestation.attestationServiceURL}. Status code: ${status}`
-    )
+    throw new Error(`Status code: ${status}. Error: ${body.error}`)
   } catch (error) {
     // This is considered a recoverable error because the user may have received the code in a previous run
     // So instead of propagating the error, we catch it just update status. This will trigger the modal,
     // allowing the user to enter codes manually or skip verification.
-    Logger.error(TAG + '@tryRevealPhoneNumber', `Reveal for issuer ${issuer} failed`, error)
+    Logger.error(
+      TAG + '@tryRevealPhoneNumber',
+      `Reveal for issuer ${issuer} with url ${attestation.attestationServiceURL} failed`,
+      error
+    )
     ValoraAnalytics.track(VerificationEvents.verification_reveal_attestation_error, {
       issuer,
       error: error.message,

--- a/packages/mobile/src/identity/verification.ts
+++ b/packages/mobile/src/identity/verification.ts
@@ -346,10 +346,10 @@ export function* doVerificationFlowSaga(action: ReturnType<typeof doVerification
       if (Platform.OS === 'android') {
         autoRetrievalTask?.cancel()
       }
+
+      yield put(setMtwAddress(unverifiedMtwAddress))
     }
 
-    const komenci: KomenciContext = yield select(komenciContextSelector)
-    yield put(setMtwAddress(komenci.unverifiedMtwAddress))
     yield put(setVerificationStatus(VerificationStatus.Done))
     yield put(setNumberVerified(true))
     yield put(succeed())

--- a/packages/mobile/src/identity/verification.ts
+++ b/packages/mobile/src/identity/verification.ts
@@ -87,6 +87,7 @@ import {
   succeed,
   verificationStatusSelector,
 } from 'src/verify/reducer'
+import { setMtwAddress } from 'src/web3/actions'
 import { getContractKit } from 'src/web3/contracts'
 import { registerAccountDek } from 'src/web3/dataEncryptionKey'
 import { getConnectedUnlockedAccount } from 'src/web3/saga'
@@ -347,6 +348,8 @@ export function* doVerificationFlowSaga(action: ReturnType<typeof doVerification
       }
     }
 
+    const komenci: KomenciContext = yield select(komenciContextSelector)
+    yield put(setMtwAddress(komenci.unverifiedMtwAddress))
     yield put(setVerificationStatus(VerificationStatus.Done))
     yield put(setNumberVerified(true))
     yield put(succeed())

--- a/packages/mobile/src/identity/verification.ts
+++ b/packages/mobile/src/identity/verification.ts
@@ -918,7 +918,7 @@ function* completeAttestation(
   // to ensure `processingInputCode` has enough time to properly gate the tx. 0-index code
   // will have 0 delay, 1-index code will have 1 sec delay, etc.
   if (shouldUseKomenci) {
-    yield delay(codePosition * 3000)
+    yield delay(codePosition * 5000)
     yield inputAttestationCodeLock.acquireAsync()
     const completeTxResult: Result<CeloTxReceipt, FetchError | TxError> = yield call(
       submitCompleteTxAndRetryOnRevert,

--- a/packages/mobile/src/verify/saga.ts
+++ b/packages/mobile/src/verify/saga.ts
@@ -92,6 +92,7 @@ import {
   stop,
   withoutRevealingSelector,
 } from 'src/verify/reducer'
+import { setMtwAddress } from 'src/web3/actions'
 import { getContractKit } from 'src/web3/contracts'
 import { registerWalletAndDekViaKomenci } from 'src/web3/dataEncryptionKey'
 import { getAccount, getConnectedUnlockedAccount, unlockAccount, UnlockResult } from 'src/web3/saga'
@@ -496,6 +497,7 @@ export function* fetchOrDeployMtwSaga() {
     const verifiedMtwAddress = yield call(fetchVerifiedMtw, contractKit, walletAddress)
     if (verifiedMtwAddress) {
       yield put(doVerificationFlow(true))
+      yield put(setMtwAddress(verifiedMtwAddress))
       return
     }
 
@@ -577,6 +579,7 @@ export function* fetchOrDeployMtwSaga() {
     yield put(setKomenciContext({ unverifiedMtwAddress }))
     yield call(feelessDekAndWalletRegistration, komenciKit, walletAddress, unverifiedMtwAddress)
     yield put(fetchOnChainData())
+    yield put(setMtwAddress(unverifiedMtwAddress))
   } catch (e) {
     storeTimestampIfKomenciError(e)
     put(setKomenciAvailable(KomenciAvailable.No))

--- a/packages/mobile/src/verify/saga.ts
+++ b/packages/mobile/src/verify/saga.ts
@@ -92,7 +92,6 @@ import {
   stop,
   withoutRevealingSelector,
 } from 'src/verify/reducer'
-import { setMtwAddress } from 'src/web3/actions'
 import { getContractKit } from 'src/web3/contracts'
 import { registerWalletAndDekViaKomenci } from 'src/web3/dataEncryptionKey'
 import { getAccount, getConnectedUnlockedAccount, unlockAccount, UnlockResult } from 'src/web3/saga'
@@ -497,7 +496,6 @@ export function* fetchOrDeployMtwSaga() {
     const verifiedMtwAddress = yield call(fetchVerifiedMtw, contractKit, walletAddress)
     if (verifiedMtwAddress) {
       yield put(doVerificationFlow(true))
-      yield put(setMtwAddress(verifiedMtwAddress))
       return
     }
 
@@ -579,7 +577,6 @@ export function* fetchOrDeployMtwSaga() {
     yield put(setKomenciContext({ unverifiedMtwAddress }))
     yield call(feelessDekAndWalletRegistration, komenciKit, walletAddress, unverifiedMtwAddress)
     yield put(fetchOnChainData())
-    yield put(setMtwAddress(unverifiedMtwAddress))
   } catch (e) {
     storeTimestampIfKomenciError(e)
     put(setKomenciAvailable(KomenciAvailable.No))

--- a/packages/mobile/src/verify/saga.ts
+++ b/packages/mobile/src/verify/saga.ts
@@ -39,7 +39,6 @@ import { ErrorMessages } from 'src/app/ErrorMessages'
 import networkConfig from 'src/geth/networkConfig'
 import { celoTokenBalanceSelector } from 'src/goldToken/selectors'
 import {
-  Actions,
   setVerificationStatus as setOldVerificationStatus,
   updateE164PhoneNumberSalts,
 } from 'src/identity/actions'
@@ -689,6 +688,4 @@ export function* verifySaga() {
   yield takeEvery(fail.type, failSaga)
   yield takeEvery(reset.type, resetSaga)
   yield takeEvery(stop.type, stopSaga)
-  // TODO: this can be calculated in reducer, once we stop using identify/reducer for verification
-  yield takeEvery(Actions.COMPLETE_ATTESTATION_CODE, fetchOnChainDataSaga)
 }


### PR DESCRIPTION
### Description

- Set the MTW during onboarding so that it can be used to reclaim escrow (and other things probably).
- Make a delay a bit larger to avoid race condition.
- Avoid calling the verification saga more than once by not calling `fetchOnChainData` when an attestation is completed.
- Make sure a lock is released when an error happens.
- Add more logs in general.

### Other changes

N/A

### Tested

Manually, I invited myself and reclaimed a few times. I temporarily changed the code of the send flow a bit to allow me to invite my phone number even though I already have an account.

### How others should test

- Invite a new phone number to join Valora
- Redeem the invite and reclaim the funds.

### Related issues

- Fixes #357
- Fixes #313

### Backwards compatibility

N/A