### PR TITLE
Fix error running iOS e2e test locally

### DIFF
--- a/packages/mobile/src/analytics/ValoraAnalytics.ts
+++ b/packages/mobile/src/analytics/ValoraAnalytics.ts
@@ -7,9 +7,10 @@ import DeviceInfo from 'react-native-device-info'
 import { check, PERMISSIONS, request, RESULTS } from 'react-native-permissions'
 import { AppEvents } from 'src/analytics/Events'
 import { AnalyticsPropertiesList } from 'src/analytics/Properties'
-import { DEFAULT_TESTNET, isE2EEnv, SEGMENT_API_KEY } from 'src/config'
+import { DEFAULT_TESTNET, FIREBASE_ENABLED, isE2EEnv, SEGMENT_API_KEY } from 'src/config'
 import { store } from 'src/redux/store'
 import Logger from 'src/utils/Logger'
+import { isPresent } from 'src/utils/typescript'
 
 const TAG = 'ValoraAnalytics'
 
@@ -45,7 +46,7 @@ async function getDeviceInfo() {
 }
 
 const SEGMENT_OPTIONS: analytics.Configuration = {
-  using: [Firebase, Adjust],
+  using: [FIREBASE_ENABLED ? Firebase : undefined, Adjust].filter(isPresent),
   flushAt: 20,
   debug: __DEV__,
   trackAppLifecycleEvents: true,


### PR DESCRIPTION
### Description

There was an error about missing Google services plist when running `yarn test:e2e:ios` locally with decrypted secrets.
This was because the analytics class tried to initialize Firebase even when `FIREBASE_ENABLED` was `false`, which is the case for the e2e run.

Note: This didn't happened on CI because the secrets are not decrypted there and the analytics class was not trying to do anything (`SEGMENT_API_KEY` being empty).

### Tested

`yarn test:e2e:ios` works locally.

### How others should test

N/A

### Backwards compatibility

Yes