### PR TITLE
[Wallet] Fix `getAttestationCodeForSecurityCode` not logging error details

### DIFF
--- a/packages/mobile/src/identity/securityCode.test.ts
+++ b/packages/mobile/src/identity/securityCode.test.ts
@@ -1,0 +1,156 @@
+import {
+  ActionableAttestation,
+  AttestationsWrapper,
+} from '@celo/contractkit/lib/wrappers/Attestations'
+import { PhoneNumberHashDetails } from '@celo/identity/lib/odis/phone-number-identifier'
+import { getAttestationCodeForSecurityCode } from 'src/identity/securityCode'
+import Logger from 'src/utils/Logger'
+import { mockAccount, mockE164Number, mockE164NumberHash, mockE164NumberPepper } from 'test/values'
+
+const testSecurityCode = '51365977'
+const phoneHashDetails: PhoneNumberHashDetails = {
+  e164Number: mockE164Number,
+  phoneHash: mockE164NumberHash,
+  pepper: mockE164NumberPepper,
+}
+const mockActionableAttestations: ActionableAttestation[] = [
+  {
+    issuer: '5', // <- matches the first digit of testSecurityCode modulo 10
+    blockNumber: 100,
+    attestationServiceURL: 'https://fake.celo.org/0',
+    name: '',
+    version: '1.1.0',
+  },
+  {
+    issuer: '15', // <- matches the first digit of testSecurityCode modulo 10
+    blockNumber: 110,
+    attestationServiceURL: 'https://fake.celo.org/1',
+    name: '',
+    version: '1.1.0',
+  },
+  {
+    issuer: '25', // <- matches the first digit of testSecurityCode modulo 10
+    blockNumber: 120,
+    attestationServiceURL: 'https://fake.celo.org/2',
+    name: '',
+    version: '1.1.0',
+  },
+]
+
+const spyLoggerError = jest.spyOn(Logger, 'error')
+
+describe(getAttestationCodeForSecurityCode, () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('returns the first successful code from getAttestationForSecurityCode', async () => {
+    const mockAttestationsWrapper = {
+      getAttestationForSecurityCode: jest
+        .fn()
+        .mockRejectedValueOnce(new Error('expected error 1'))
+        .mockRejectedValueOnce(new Error('expected error 2'))
+        .mockResolvedValueOnce('SUCCESS_ATTESTATION_CODE'),
+    }
+
+    await expect(
+      getAttestationCodeForSecurityCode(
+        (mockAttestationsWrapper as unknown) as AttestationsWrapper,
+        phoneHashDetails,
+        mockAccount,
+        mockActionableAttestations,
+        testSecurityCode,
+        'TestSigner'
+      )
+    ).resolves.toBe('SUCCESS_ATTESTATION_CODE')
+
+    expect(mockAttestationsWrapper.getAttestationForSecurityCode.mock.calls).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          "https://fake.celo.org/0",
+          Object {
+            "account": "0x0000000000000000000000000000000000007E57",
+            "issuer": "5",
+            "phoneNumber": "+14155550000",
+            "salt": "piWqRHHYWtfg9",
+            "securityCode": "1365977",
+          },
+          "TestSigner",
+        ],
+        Array [
+          "https://fake.celo.org/1",
+          Object {
+            "account": "0x0000000000000000000000000000000000007E57",
+            "issuer": "15",
+            "phoneNumber": "+14155550000",
+            "salt": "piWqRHHYWtfg9",
+            "securityCode": "1365977",
+          },
+          "TestSigner",
+        ],
+        Array [
+          "https://fake.celo.org/2",
+          Object {
+            "account": "0x0000000000000000000000000000000000007E57",
+            "issuer": "25",
+            "phoneNumber": "+14155550000",
+            "salt": "piWqRHHYWtfg9",
+            "securityCode": "1365977",
+          },
+          "TestSigner",
+        ],
+      ]
+    `)
+
+    // check it logs an error for each individual call to getAttestationForSecurityCode that throws
+    expect(spyLoggerError).toHaveBeenCalledTimes(2)
+  })
+
+  it('throws an error when all getAttestationForSecurityCode fail', async () => {
+    const mockAttestationsWrapper = {
+      getAttestationForSecurityCode: jest
+        .fn()
+        .mockRejectedValueOnce(new Error('expected error 1'))
+        .mockRejectedValueOnce(new Error('expected error 2'))
+        .mockRejectedValueOnce(new Error('expected error 3')),
+    }
+
+    await expect(
+      getAttestationCodeForSecurityCode(
+        (mockAttestationsWrapper as unknown) as AttestationsWrapper,
+        phoneHashDetails,
+        mockAccount,
+        mockActionableAttestations,
+        testSecurityCode,
+        'TestSigner'
+      )
+    ).rejects.toThrowErrorMatchingInlineSnapshot(`
+            "raceUntilSuccess all failed:
+            Error: expected error 1
+            Error: expected error 2
+            Error: expected error 3"
+          `)
+
+    // check it logs an error for each individual call to getAttestationForSecurityCode that throws
+    expect(spyLoggerError).toHaveBeenCalledTimes(3)
+  })
+
+  it('throws an error when no issuer matches the security code', async () => {
+    const mockAttestationsWrapper = {
+      getAttestationForSecurityCode: jest.fn().mockRejectedValue(new Error('Some test error')),
+    }
+
+    await expect(
+      getAttestationCodeForSecurityCode(
+        (mockAttestationsWrapper as unknown) as AttestationsWrapper,
+        phoneHashDetails,
+        mockAccount,
+        mockActionableAttestations,
+        '12345', // a different security code
+        'TestSigner'
+      )
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `"Unable to find possible issuers for security code: 12345, attestation issuers: [5,15,25]"`
+    )
+  })
+})

--- a/packages/mobile/src/identity/securityCode.ts
+++ b/packages/mobile/src/identity/securityCode.ts
@@ -45,7 +45,7 @@ export async function getAttestationCodeForSecurityCode(
   )
 
   if (lookupAttestations.length <= 0) {
-    // This shouldn't happen
+    // This shouldn't happen when the code is legit
     throw new Error(
       `Unable to find possible issuers for security code: ${securityCodeWithPrefix}, attestation issuers: [${attestations.map(
         (attestation) => attestation.issuer


### PR DESCRIPTION
### Description

Fix `getAttestationCodeForSecurityCode` not logging error details.
Also handle case where no matching issuer is found and add unit tests.

### Tested

Added unit tests.

### How others should test

1. Start verification process
2. Manually input incorrect verification codes on purpose
3. Check app logs and ensure `identity/verification@attestationCodeReceiver :: Error processing attestation code` shows the real error and NOT `unknown`

### Related issues

- Fixes #371

### Backwards compatibility

Yes