### PR TITLE
Add logging for `tryRevealPhoneNumber`

### DIFF
--- a/packages/mobile/src/analytics/ValoraAnalytics.ts
+++ b/packages/mobile/src/analytics/ValoraAnalytics.ts
@@ -7,9 +7,10 @@ import DeviceInfo from 'react-native-device-info'
 import { check, PERMISSIONS, request, RESULTS } from 'react-native-permissions'
 import { AppEvents } from 'src/analytics/Events'
 import { AnalyticsPropertiesList } from 'src/analytics/Properties'
-import { DEFAULT_TESTNET, isE2EEnv, SEGMENT_API_KEY } from 'src/config'
+import { DEFAULT_TESTNET, FIREBASE_ENABLED, isE2EEnv, SEGMENT_API_KEY } from 'src/config'
 import { store } from 'src/redux/store'
 import Logger from 'src/utils/Logger'
+import { isPresent } from 'src/utils/typescript'
 
 const TAG = 'ValoraAnalytics'
 
@@ -45,7 +46,7 @@ async function getDeviceInfo() {
 }
 
 const SEGMENT_OPTIONS: analytics.Configuration = {
-  using: [Firebase, Adjust],
+  using: [FIREBASE_ENABLED ? Firebase : undefined, Adjust].filter(isPresent),
   flushAt: 20,
   debug: __DEV__,
   trackAppLifecycleEvents: true,

--- a/packages/mobile/src/identity/securityCode.test.ts
+++ b/packages/mobile/src/identity/securityCode.test.ts
@@ -1,0 +1,156 @@
+import {
+  ActionableAttestation,
+  AttestationsWrapper,
+} from '@celo/contractkit/lib/wrappers/Attestations'
+import { PhoneNumberHashDetails } from '@celo/identity/lib/odis/phone-number-identifier'
+import { getAttestationCodeForSecurityCode } from 'src/identity/securityCode'
+import Logger from 'src/utils/Logger'
+import { mockAccount, mockE164Number, mockE164NumberHash, mockE164NumberPepper } from 'test/values'
+
+const testSecurityCode = '51365977'
+const phoneHashDetails: PhoneNumberHashDetails = {
+  e164Number: mockE164Number,
+  phoneHash: mockE164NumberHash,
+  pepper: mockE164NumberPepper,
+}
+const mockActionableAttestations: ActionableAttestation[] = [
+  {
+    issuer: '5', // <- matches the first digit of testSecurityCode modulo 10
+    blockNumber: 100,
+    attestationServiceURL: 'https://fake.celo.org/0',
+    name: '',
+    version: '1.1.0',
+  },
+  {
+    issuer: '15', // <- matches the first digit of testSecurityCode modulo 10
+    blockNumber: 110,
+    attestationServiceURL: 'https://fake.celo.org/1',
+    name: '',
+    version: '1.1.0',
+  },
+  {
+    issuer: '25', // <- matches the first digit of testSecurityCode modulo 10
+    blockNumber: 120,
+    attestationServiceURL: 'https://fake.celo.org/2',
+    name: '',
+    version: '1.1.0',
+  },
+]
+
+const spyLoggerError = jest.spyOn(Logger, 'error')
+
+describe(getAttestationCodeForSecurityCode, () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('returns the first successful code from getAttestationForSecurityCode', async () => {
+    const mockAttestationsWrapper = {
+      getAttestationForSecurityCode: jest
+        .fn()
+        .mockRejectedValueOnce(new Error('expected error 1'))
+        .mockRejectedValueOnce(new Error('expected error 2'))
+        .mockResolvedValueOnce('SUCCESS_ATTESTATION_CODE'),
+    }
+
+    await expect(
+      getAttestationCodeForSecurityCode(
+        (mockAttestationsWrapper as unknown) as AttestationsWrapper,
+        phoneHashDetails,
+        mockAccount,
+        mockActionableAttestations,
+        testSecurityCode,
+        'TestSigner'
+      )
+    ).resolves.toBe('SUCCESS_ATTESTATION_CODE')
+
+    expect(mockAttestationsWrapper.getAttestationForSecurityCode.mock.calls).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          "https://fake.celo.org/0",
+          Object {
+            "account": "0x0000000000000000000000000000000000007E57",
+            "issuer": "5",
+            "phoneNumber": "+14155550000",
+            "salt": "piWqRHHYWtfg9",
+            "securityCode": "1365977",
+          },
+          "TestSigner",
+        ],
+        Array [
+          "https://fake.celo.org/1",
+          Object {
+            "account": "0x0000000000000000000000000000000000007E57",
+            "issuer": "15",
+            "phoneNumber": "+14155550000",
+            "salt": "piWqRHHYWtfg9",
+            "securityCode": "1365977",
+          },
+          "TestSigner",
+        ],
+        Array [
+          "https://fake.celo.org/2",
+          Object {
+            "account": "0x0000000000000000000000000000000000007E57",
+            "issuer": "25",
+            "phoneNumber": "+14155550000",
+            "salt": "piWqRHHYWtfg9",
+            "securityCode": "1365977",
+          },
+          "TestSigner",
+        ],
+      ]
+    `)
+
+    // check it logs an error for each individual call to getAttestationForSecurityCode that throws
+    expect(spyLoggerError).toHaveBeenCalledTimes(2)
+  })
+
+  it('throws an error when all getAttestationForSecurityCode fail', async () => {
+    const mockAttestationsWrapper = {
+      getAttestationForSecurityCode: jest
+        .fn()
+        .mockRejectedValueOnce(new Error('expected error 1'))
+        .mockRejectedValueOnce(new Error('expected error 2'))
+        .mockRejectedValueOnce(new Error('expected error 3')),
+    }
+
+    await expect(
+      getAttestationCodeForSecurityCode(
+        (mockAttestationsWrapper as unknown) as AttestationsWrapper,
+        phoneHashDetails,
+        mockAccount,
+        mockActionableAttestations,
+        testSecurityCode,
+        'TestSigner'
+      )
+    ).rejects.toThrowErrorMatchingInlineSnapshot(`
+            "raceUntilSuccess all failed:
+            Error: expected error 1
+            Error: expected error 2
+            Error: expected error 3"
+          `)
+
+    // check it logs an error for each individual call to getAttestationForSecurityCode that throws
+    expect(spyLoggerError).toHaveBeenCalledTimes(3)
+  })
+
+  it('throws an error when no issuer matches the security code', async () => {
+    const mockAttestationsWrapper = {
+      getAttestationForSecurityCode: jest.fn().mockRejectedValue(new Error('Some test error')),
+    }
+
+    await expect(
+      getAttestationCodeForSecurityCode(
+        (mockAttestationsWrapper as unknown) as AttestationsWrapper,
+        phoneHashDetails,
+        mockAccount,
+        mockActionableAttestations,
+        '12345', // a different security code
+        'TestSigner'
+      )
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `"Unable to find possible issuers for security code: 12345, attestation issuers: [5,15,25]"`
+    )
+  })
+})

--- a/packages/mobile/src/identity/securityCode.ts
+++ b/packages/mobile/src/identity/securityCode.ts
@@ -22,7 +22,10 @@ async function raceUntilSuccess<T>(promises: Array<Promise<T>>) {
         })
       })
     )
-    return Promise.reject(errors)
+    // TODO: use AggregateError when available
+    return Promise.reject(
+      new Error(`raceUntilSuccess all failed:\n${errors.map((error) => String(error)).join('\n')}`)
+    )
   } catch (firstValue) {
     return Promise.resolve(firstValue)
   }
@@ -40,6 +43,15 @@ export async function getAttestationCodeForSecurityCode(
   const lookupAttestations = attestations.filter(
     (attestation) => getSecurityCodePrefix(attestation.issuer) === securityCodePrefix
   )
+
+  if (lookupAttestations.length <= 0) {
+    // This shouldn't happen when the code is legit
+    throw new Error(
+      `Unable to find possible issuers for security code: ${securityCodeWithPrefix}, attestation issuers: [${attestations.map(
+        (attestation) => attestation.issuer
+      )}]`
+    )
+  }
 
   // Recover the full attestation code from the matching issuer's attestation services
   return raceUntilSuccess(
@@ -78,7 +90,7 @@ async function requestValidator(
       securityCode,
     }
 
-    return attestationsWrapper.getAttestationForSecurityCode(
+    return await attestationsWrapper.getAttestationForSecurityCode(
       attestation.attestationServiceURL,
       requestBody,
       signer

--- a/packages/mobile/src/identity/verification.ts
+++ b/packages/mobile/src/identity/verification.ts
@@ -1055,14 +1055,16 @@ export function* tryRevealPhoneNumber(
       )
     )
 
-    throw new Error(
-      `Error revealing to issuer ${attestation.attestationServiceURL}. Status code: ${status}`
-    )
+    throw new Error(`Status code: ${status}. Error: ${body.error}`)
   } catch (error) {
     // This is considered a recoverable error because the user may have received the code in a previous run
     // So instead of propagating the error, we catch it just update status. This will trigger the modal,
     // allowing the user to enter codes manually or skip verification.
-    Logger.error(TAG + '@tryRevealPhoneNumber', `Reveal for issuer ${issuer} failed`, error)
+    Logger.error(
+      TAG + '@tryRevealPhoneNumber',
+      `Reveal for issuer ${issuer} with url ${attestation.attestationServiceURL} failed`,
+      error
+    )
     ValoraAnalytics.track(VerificationEvents.verification_reveal_attestation_error, {
       issuer,
       error: error.message,


### PR DESCRIPTION
### Description
- Add logging of error message for `tryRevealPhoneNumber`. This will add more context for the `Status code: 422` errors in the logs
- Standardize error messaging of `tryRevealPhoneNumber`for analytics purpose. Including issuer URL in the analytics error was making it difficult to group identical errors that were happening across several different issuers

### Other changes
N/A

### Tested
N/A

### How others should test
N/A

### Related issues
N/A

### Backwards compatibility
Yes