### PR TITLE
[WalletConnect] implement eth_signTypedData

### DIFF
--- a/packages/mobile/src/walletConnect/saga.ts
+++ b/packages/mobile/src/walletConnect/saga.ts
@@ -138,6 +138,9 @@ export function* acceptRequest({
     if (method === SupportedActions.eth_signTransaction) {
       yield call(unlockAccount, account)
       result = (yield call(wallet.signTransaction.bind(wallet), params)) as EncodedTransaction
+    } else if (method == SupportedActions.eth_signTypedData) {
+      yield call(unlockAccount, account)
+      result = yield call(wallet.signTypedData.bind(wallet), account, JSON.parse(params[1]))
     } else {
       throw new Error('Unsupported action')
     }

--- a/packages/mobile/src/walletConnect/saga.ts
+++ b/packages/mobile/src/walletConnect/saga.ts
@@ -163,7 +163,7 @@ export function* acceptRequest({
 
     yield call(client.respond.bind(client), {
       topic,
-      response: response,
+      response,
     })
   } catch (e) {
     Logger.debug(TAG + '@acceptRequest', e.message)

--- a/packages/mobile/src/walletConnect/saga.ts
+++ b/packages/mobile/src/walletConnect/saga.ts
@@ -134,10 +134,9 @@ export function* acceptRequest({
     const wallet: UnlockableWallet = yield call(getWallet)
 
     let result: any
-    // Default error
     let error: ErrorType | undefined
     try {
-      // If no `result` is set here, error is presumed
+      // Set `result` or `error` accordingly
       switch (method) {
         case SupportedActions.eth_signTransaction:
           yield call(unlockAccount, account)

--- a/packages/mobile/src/walletConnect/saga.ts
+++ b/packages/mobile/src/walletConnect/saga.ts
@@ -135,7 +135,7 @@ export function* acceptRequest({
 
     let result: any
     // Default error
-    let error: ErrorType = WalletConnectErrors.GENERIC
+    let error: ErrorType | undefined
     try {
       // If no `result` is set here, error is presumed
       switch (method) {
@@ -152,14 +152,13 @@ export function* acceptRequest({
       }
     } catch (e) {
       Logger.debug(TAG + '@acceptRequest error obtaining result: ', e.message)
+      error = WalletConnectErrors.GENERIC
     }
     const partialResponse = { id, jsonrpc }
-    let response
-
-    response =
+    const response =
       result !== undefined
         ? { ...partialResponse, result }
-        : { ...partialResponse, error: getError(error) }
+        : { ...partialResponse, error: getError(error!) }
 
     yield call(client.respond.bind(client), {
       topic,


### PR DESCRIPTION
### Description
- implements `eth_signTypedData`

### Other changes
- adds minimal additional error handling which should now be propagated as a response

### Tested
- Manually via `use-contractkit` and by extending the `run-in-memory-client.ts` script in the `celo-monorepo` (in [this small PR](https://github.com/celo-org/celo-monorepo/pull/7951))

### Related issues
- Fixes celo-org/celo-monorepo#7514
### Backwards compatibility

cc @medhak1 as this changes some of the structure in the `acceptRequest` function in `../saga.ts`, assuming that will be relevant for `personal_decrypt` or the other json RPC methods you're implementing!
