### PR TITLE
Prevent repeated code from being pasted in Android

### DIFF
--- a/packages/mobile/src/identity/actions.ts
+++ b/packages/mobile/src/identity/actions.ts
@@ -98,6 +98,7 @@ export interface SetCompletedCodesAction {
 export interface InputAttestationCodeAction {
   type: Actions.INPUT_ATTESTATION_CODE
   code: AttestationCode
+  index?: number
 }
 
 export interface CompleteAttestationCodeAction {
@@ -314,9 +315,13 @@ export const setCompletedCodes = (numComplete: number): SetCompletedCodesAction 
   numComplete,
 })
 
-export const inputAttestationCode = (code: AttestationCode): InputAttestationCodeAction => ({
+export const inputAttestationCode = (
+  code: AttestationCode,
+  index?: number
+): InputAttestationCodeAction => ({
   type: Actions.INPUT_ATTESTATION_CODE,
   code,
+  index,
 })
 
 export const completeAttestationCode = (code: AttestationCode): CompleteAttestationCodeAction => ({

--- a/packages/mobile/src/identity/smsRetrieval.ts
+++ b/packages/mobile/src/identity/smsRetrieval.ts
@@ -20,7 +20,7 @@ export function* startAutoSmsRetrieval() {
   })
   yield call(startSmsRetriever)
   try {
-    let messages: string[] = []
+    const messages: string[] = []
     while (true) {
       const { message } = yield take(autoSmsChannel)
       if (!messages.includes(message)) {

--- a/packages/mobile/src/identity/smsRetrieval.ts
+++ b/packages/mobile/src/identity/smsRetrieval.ts
@@ -20,9 +20,13 @@ export function* startAutoSmsRetrieval() {
   })
   yield call(startSmsRetriever)
   try {
+    let messages: string[] = []
     while (true) {
       const { message } = yield take(autoSmsChannel)
-      yield put(receiveAttestationMessage(message, CodeInputType.AUTOMATIC))
+      if (!messages.includes(message)) {
+        messages.push(message)
+        yield put(receiveAttestationMessage(message, CodeInputType.AUTOMATIC))
+      }
     }
   } catch (error) {
     Logger.error(TAG + '@SmsRetriever', 'Error while retrieving code', error)

--- a/packages/mobile/src/identity/verification.ts
+++ b/packages/mobile/src/identity/verification.ts
@@ -779,9 +779,11 @@ export function attestationCodeReceiver(
         `Attestation code (${message}) is valid, starting processing (issuer: ${issuer})`
       )
 
-      yield put(setAttestationInputStatus(index, CodeInputStatus.Processing))
       yield put(
-        inputAttestationCode({ code: attestationCode, shortCode: securityCodeWithPrefix, issuer })
+        inputAttestationCode(
+          { code: attestationCode, shortCode: securityCodeWithPrefix, issuer },
+          index
+        )
       )
     } catch (error) {
       Logger.error(


### PR DESCRIPTION
### Description

When codes are autopasted on Android, they were sometimes being duplicated. I fixed this in two places:
- In the SMS receiver listener.
- In the reducer so as to prevent other duplication issues in the future. This code really needs a big refactoring to make it more consistent.

### Other changes

N/A

### Tested

Locally. It's hard to reproduce consistently so I changed the code temporarily to test so that the paste code callback is called with the same code 3 times and made sure that only the first one is handled.

### How others should test

Verify using Android and make sure that the autopasted codes are not repeated.

### Related issues

- Fixes #390

### Backwards compatibility

N/A