### PR TITLE
Fix Linux support in run_app.sh

### DIFF
--- a/packages/mobile/scripts/run_app.sh
+++ b/packages/mobile/scripts/run_app.sh
@@ -70,7 +70,13 @@ startPackager() {
       if [ "$MACHINE" = "Mac" ]; then
         open -a "$terminal" ./scripts/launch_packager.command || open ./scripts/launch_packager.command || open_failed=1
       elif [ "$MACHINE" = "Linux" ]; then
-        "$terminal" -e "sh ./scripts/launch_packager.command" || open_failed=1
+        run() {
+            exec "$terminal" -e "./scripts/launch_packager.command"
+            # Only returns if $terminal fails to exec.
+            echo "Could not open terminal '${terminal}'. Falling back to running the packager inline."
+            yarn react-native start
+        }
+        run &
       else 
         echo "Unsupported machine for running in new terminal"
         open_failed=1


### PR DESCRIPTION
### Description

Fork-exec to try to start terminal, falling back to running packager in existing terminal. This fixes the previous behavior
which blocked until the newly created terminal process returned.

### Tested

Manually on Linux.