### PR TITLE
Update text of RaiseLimitScreen

### DIFF
--- a/packages/mobile/src/account/RaiseLimitScreen.tsx
+++ b/packages/mobile/src/account/RaiseLimitScreen.tsx
@@ -132,7 +132,7 @@ const RaiseLimitScreen = () => {
       </Text>
       {!dailyLimitRequestStatus && (
         <Text style={styles.bodyText}>
-          {numberIsVerified ? t('verifyNumberToRaiseLimit') : t('verifyIdentityToRaiseLimit')}
+          {numberIsVerified ? t('verifyIdentityToRaiseLimit') : t('verifyNumberToRaiseLimit')}
         </Text>
       )}
       {applicationStatusTexts && (

--- a/packages/mobile/src/account/__snapshots__/RaiseLimitScreen.test.tsx.snap
+++ b/packages/mobile/src/account/__snapshots__/RaiseLimitScreen.test.tsx.snap
@@ -45,7 +45,7 @@ exports[`RaiseLimitScreen renders correctly 1`] = `
       }
     }
   >
-    verifyNumberToRaiseLimit
+    verifyIdentityToRaiseLimit
   </Text>
   <View
     style={

--- a/packages/mobile/src/firebase/firebase.ts
+++ b/packages/mobile/src/firebase/firebase.ts
@@ -229,7 +229,7 @@ export function appRemoteFeatureFlagChannel() {
       Logger.debug(`Updated feature flags: ${JSON.stringify(flags)}`)
       emit({
         hideVerification: flags?.hideVerification ?? false,
-        showRaiseDailyLimitTarget: flags?.showRaiseDailyLimitTarget ?? undefined,
+        showRaiseDailyLimitTarget: flags?.showRaiseDailyLimitTargetV2 ?? undefined,
         celoEducationUri: flags?.celoEducationUri ?? null,
         shortVerificationCodesEnabled: flags?.shortVerificationCodesEnabled ?? false,
         inviteRewardsEnabled: flags?.inviteRewardsEnabled ?? false,


### PR DESCRIPTION
### Description

The description text in the `RaiseLimitScreen` was flipped for verified and unverified users. Not it isn't

<img width="388" alt="Screen Shot 2021-05-26 at 17 32 01" src="https://user-images.githubusercontent.com/6062888/119727504-be073c00-be48-11eb-8912-3020479a9509.png">

<img width="366" alt="Screen Shot 2021-05-26 at 17 31 45" src="https://user-images.githubusercontent.com/6062888/119727498-bc3d7880-be48-11eb-8276-182d9eb1ebb9.png">


### Other changes

N/A

### Tested

Manually, went to the screen (see screenshots)


### How others should test

Go to the raise limit screen and check that the text there makes sense with your verification status.

### Related issues

- Fixes #407

### Backwards compatibility

N/A