### PR TITLE
Display contact phone numbers in the same format they are saved in

### DIFF
--- a/packages/mobile/src/recipients/recipient.test.ts
+++ b/packages/mobile/src/recipients/recipient.test.ts
@@ -9,6 +9,7 @@ describe('contactsToRecipients', () => {
       {
         recordID: '1',
         displayName: 'Alice The Person',
+        thumbnailPath: 'does-not-matter',
         phoneNumbers: [
           {
             label: 'mobile',
@@ -18,6 +19,7 @@ describe('contactsToRecipients', () => {
       },
       {
         recordID: '2',
+        thumbnailPath: 'does-not-matter',
         displayName: 'Bob Bobson',
         phoneNumbers: [
           { label: 'home', number: '+14155550000' },

--- a/packages/mobile/src/recipients/recipient.test.ts
+++ b/packages/mobile/src/recipients/recipient.test.ts
@@ -1,19 +1,37 @@
+import { MinimalContact } from 'react-native-contacts'
 import { contactsToRecipients, sortRecipients } from 'src/recipients/recipient'
-import { mockContactList, mockRecipient, mockRecipient2, mockRecipient3 } from 'test/values'
+import { mockRecipient, mockRecipient2, mockRecipient3 } from 'test/values'
 
 describe('contactsToRecipients', () => {
   it('returns a recipient per phone number', () => {
     const countryCode = '+1'
-    const recipients = contactsToRecipients(mockContactList, countryCode)
+    const mockContacts: MinimalContact[] = [
+      {
+        recordID: '1',
+        displayName: 'Alice The Person',
+        phoneNumbers: [
+          {
+            label: 'mobile',
+            number: '(209) 555-9790',
+          },
+        ],
+      },
+      {
+        recordID: '2',
+        displayName: 'Bob Bobson',
+        phoneNumbers: [
+          { label: 'home', number: '+14155550000' },
+          { label: 'mobile', number: '100200' },
+        ],
+      },
+    ]
 
-    if (!recipients) {
-      return expect(false).toBeTruthy()
-    }
+    const recipients = contactsToRecipients(mockContacts, countryCode)
 
     expect(recipients).toMatchObject({
       '+14155550000': {
         name: 'Bob Bobson',
-        displayNumber: '(415) 555-0000',
+        displayNumber: '+14155550000',
         e164PhoneNumber: '+14155550000',
         contactId: '2',
       },

--- a/packages/mobile/src/recipients/recipient.ts
+++ b/packages/mobile/src/recipients/recipient.ts
@@ -104,7 +104,8 @@ export function contactsToRecipients(contacts: MinimalContact[], defaultCountryC
           }
           e164NumberToRecipients[parsedNumber.e164Number] = {
             name: contact.displayName,
-            displayNumber: parsedNumber.displayNumber,
+            // We intentionally use phoneNumber.number rather than parsedNumber.displayNumber.
+            displayNumber: phoneNumber.number,
             e164PhoneNumber: parsedNumber.e164Number,
             // @ts-ignore TODO Minimal contact type is incorrect, on android it returns id
             contactId: contact.recordID || contact.id,


### PR DESCRIPTION
### Description

See https://github.com/celo-org/wallet/issues/34.

### Tested

Updated unit tests and ad hoc testing in an emulator.

### How others should test

* Add a phone number with a country code.  E.g., `+41 044 668 18 00`.
* Phone number should render the same as it was entered instead of the international format.  E.g., `+41 044 668 18 00` instead of `044 668 18 00`.`

### Related issues

Fixes https://github.com/celo-org/wallet/issues/34