### PR TITLE
Fixed the blockscout query parameter type

### DIFF
--- a/packages/blockchain-api/src/blockscout.ts
+++ b/packages/blockchain-api/src/blockscout.ts
@@ -65,7 +65,7 @@ export class BlockscoutAPI extends RESTDataSource {
 
     const response = await this.post('', {
       query: `
-        query Transfers($address: String!) {
+        query Transfers($address: AddressHash!) {
           # TXs related to cUSD or cGLD transfers
           transferTxs(addressHash: $address, first: 100) {
             edges {


### PR DESCRIPTION
### Description

The argument parameter was incorrect as according to the doc it should be `AddressHash`. The new version of blockscout is stricter and validates it.

### Tested

Tested on rc1.

### How others should test

Copy the whole query and test it on the graphql page of blockscout https://explorer.celo.org/graphiql.

### Related issues

n/a

### Backwards compatibility

Yes.