### PR TITLE
Fix miscount in attestation rerequest banner

### DIFF
--- a/packages/mobile/src/verify/revealAttestations.ts
+++ b/packages/mobile/src/verify/revealAttestations.ts
@@ -5,12 +5,11 @@ import {
   getSecurityCodePrefix,
 } from '@celo/contractkit/lib/wrappers/Attestations'
 import { PhoneNumberHashDetails } from '@celo/identity/lib/odis/phone-number-identifier'
+import { AttestationRequest } from '@celo/utils/lib/io'
 import { Platform } from 'react-native'
 import { call, delay, put, select } from 'redux-saga/effects'
 import { VerificationEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
-
-import { AttestationRequest } from '@celo/utils/lib/io'
 import { currentLanguageSelector } from 'src/app/reducers'
 import { shortVerificationCodesEnabledSelector } from 'src/app/selectors'
 import { SMS_RETRIEVER_APP_SIGNATURE } from 'src/config'
@@ -22,10 +21,10 @@ import {
   OnChainVerificationStatus,
   reportRevealStatus,
   requestAttestations,
-  REVEAL_RETRY_DELAY,
   RevealStatus,
   RevealStatuses,
   revealStatusesSelector,
+  REVEAL_RETRY_DELAY,
   setLastRevealAttempt,
   setRevealStatuses,
   shouldUseKomenciSelector,
@@ -90,9 +89,11 @@ export function* revealAttestationsSaga() {
     }
   }
 
-  yield put(setLastRevealAttempt(Date.now()))
-  revealStatuses = yield select(revealStatusesSelector)
+  if (notRevealedActionableAttestations.length) {
+    yield put(setLastRevealAttempt(Date.now()))
+  }
 
+  revealStatuses = yield select(revealStatusesSelector)
   const revealedActionableAttestations = actionableAttestations.filter(
     (aa) => revealStatuses[aa.issuer] === RevealStatus.Revealed
   )

--- a/packages/mobile/src/verify/saga.ts
+++ b/packages/mobile/src/verify/saga.ts
@@ -626,7 +626,7 @@ export function* resendMessagesSaga() {
   Logger.debug(TAG, `@resendMessagesSaga has started`)
 
   const shouldUseKomenci = yield select(shouldUseKomenciSelector)
-  const status = yield select(verificationStatusSelector)
+  const status: OnChainVerificationStatus = yield select(verificationStatusSelector)
   ValoraAnalytics.track(VerificationEvents.verification_resend_messages, {
     count: status.numAttestationsRemaining,
     feeless: shouldUseKomenci,
@@ -641,7 +641,9 @@ export function* resendMessagesSaga() {
   yield put(setRevealStatuses(revealStatusesToUpdate))
   yield put(
     showMessage(
-      i18n.t('onboarding:verificationInput.sendingMessages', { count: nonConfirmedIssuers.length })
+      i18n.t('onboarding:verificationInput.sendingMessages', {
+        count: status.numAttestationsRemaining,
+      })
     )
   )
   yield put(revealAttestations())


### PR DESCRIPTION
### Description
The banner informing the user of how many text messages were being resent was based on the count of non-completed attestations, which can be greater than the number of attestations required to confirm a phone number.

### Other changes
Time of `lastRevealAttempt` was being updated even when no new attestations were being revealed. This resulted in the user having to wait 1 min to re-request a text message if even none were on the way.

### Tested
Manually


### How others should test
- Ensure the banner shows the right number of text messages requested
- If the confirmation process is started (i.e., the user reaches the `VerificationCodeInputScreen`), then the user leaves the flow and resumes the confirmation process, ensure that the user is not forced to wait 1 min before requesting more attestations 

### Related issues
- Fixes #458

### Backwards compatibility
Yes