### PR TITLE
Upgrade to node 12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,6 +67,9 @@ commands:
       - run:
           name: Install dependencies
           command: |
+            # Needed by ./scripts/sync_branding.sh
+            sudo apt-get update -y && sudo apt-get install rsync -y
+
             if [ ! -e ~/.tmp/yarn_deps_have_changed ]; then
               # Though `yarn install` is instantaneous with up-to-date node_modules which is the case when we've restored cached node_modules,
               # there's currently a bug with the generated node_modules/.yarn-integrity file which is apparently not entirely stable
@@ -84,8 +87,6 @@ commands:
             # Deals with yarn install flakiness which can come due to yarnpkg.com being
             # unreliable. For example, https://circleci.com/gh/celo-org/celo-monorepo/82685
             yarn install || yarn install || yarn install
-            # Needed by ./scripts/sync_branding.sh
-            sudo apt-get update -y && sudo apt-get install rsync -y
       - run:
           name: Fail if someone forgot to commit "yarn.lock"
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,12 +64,11 @@ commands:
               touch ~/.tmp/yarn_deps_have_changed
             fi
 
+      - install_rsync
+
       - run:
           name: Install dependencies
           command: |
-            # Needed by ./scripts/sync_branding.sh
-            sudo apt-get update -y && sudo apt-get install rsync -y
-
             if [ ! -e ~/.tmp/yarn_deps_have_changed ]; then
               # Though `yarn install` is instantaneous with up-to-date node_modules which is the case when we've restored cached node_modules,
               # there's currently a bug with the generated node_modules/.yarn-integrity file which is apparently not entirely stable
@@ -109,6 +108,13 @@ commands:
           key: node_modules-v4-{{ arch }}-{{ checksum "yarn.lock" }}-{{ checksum "~/.tmp/checksumfiles/package.json" }}-{{ checksum "~/.tmp/checksumfiles/patches" }}
           paths:
             - ~/.tmp/node_modules.tgz
+
+  install_rsync:
+    steps:
+      - run:
+          name: Install rsync
+          command: |
+            sudo apt-get update -y && sudo apt-get install rsync -y
 
 jobs:
   install_dependencies:
@@ -418,6 +424,8 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/app
+
+      - install_rsync
 
       - run:
           name: Ensure translations are not missing

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,6 +84,8 @@ commands:
             # Deals with yarn install flakiness which can come due to yarnpkg.com being
             # unreliable. For example, https://circleci.com/gh/celo-org/celo-monorepo/82685
             yarn install || yarn install || yarn install
+            # Needed by ./scripts/sync_branding.sh
+            sudo apt-get update -y && sudo apt-get install rsync -y
       - run:
           name: Fail if someone forgot to commit "yarn.lock"
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,9 +63,6 @@ commands:
               # Dependencies have changed, create beacon file used by the install and check licenses steps
               touch ~/.tmp/yarn_deps_have_changed
             fi
-
-      - install_rsync
-
       - run:
           name: Install dependencies
           command: |
@@ -150,6 +147,8 @@ jobs:
 
       - attach_workspace:
           at: ~/app
+
+      - install_rsync
 
       - yarn_install
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ reference:
 defaults: &defaults
   working_directory: ~/app
   docker:
-    - image: celohq/node10-gcloud:v3
+    - image: cimg/node:12.22.1
   environment:
     # To avoid ENOMEM problem when running node
     NODE_OPTIONS: '--max-old-space-size=4096'
@@ -219,7 +219,7 @@ jobs:
             echo -e '\nexport NVM_DIR="$HOME/.nvm"' >> ~/.bash_profile
             echo -e '\n[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> ~/.bash_profile # add nvm to path
       - run: echo `. ~/.bash_profile`
-      - run: nvm install v10.16.3 && nvm use v10.16.3
+      - run: nvm install v12.22.1 && nvm use v12.22.1
       - run:
           name: install miscellaneous
           command: |
@@ -280,7 +280,7 @@ jobs:
       - run:
           name: Configure environment variables
           command: |
-            echo 'export PATH=/usr/local/opt/node@10/bin:$PATH' >> $BASH_ENV
+            echo 'export PATH=/usr/local/opt/node@12/bin:$PATH' >> $BASH_ENV
             source $BASH_ENV
       # brew update added as temporary fix to deal with bintray sunset
       - run:
@@ -288,7 +288,7 @@ jobs:
           command: |
             set -euo pipefail
             brew update
-            brew install node@10
+            brew install node@12
             brew tap wix/brew
             brew install applesimutils
             node -v

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: '10'
+          node-version: '12'
           check-latest: true
       # https://github.com/actions/cache/blob/main/examples.md#node---lerna
       - uses: actions/cache@v2

--- a/SETUP.md
+++ b/SETUP.md
@@ -56,9 +56,8 @@ Once `nvm` is successfully installed, restart the terminal and run the following
 
 ```bash
 # restart the terminal after installing nvm
-nvm install 8
-nvm install 10
-nvm alias default 10
+nvm install 12.22.1
+nvm use 12.22.1
 ```
 
 ### MacOS

--- a/packages/blockchain-api/test/blockscout.test.ts
+++ b/packages/blockchain-api/test/blockscout.test.ts
@@ -672,14 +672,14 @@ describe('Blockscout', () => {
           "type": "EXCHANGE",
         },
         Object {
-          "account": "0x8b7649116f169d2d2aebb6ea1a77f0baf31f2811",
-          "address": "0x8b7649116f169d2d2aebb6ea1a77f0baf31f2811",
+          "account": "0x6a0edf42f5e618bee697e7718fa05efb1ea5d11c",
+          "address": "0x6a0edf42f5e618bee697e7718fa05efb1ea5d11c",
           "amount": Object {
             "currencyCode": "cUSD",
             "timestamp": 1566346276000,
             "value": "-0.15",
           },
-          "block": "90719",
+          "block": "90792",
           "comment": "",
           "fees": Array [
             Object {
@@ -699,7 +699,7 @@ describe('Blockscout', () => {
               "type": "SECURITY_FEE",
             },
           ],
-          "hash": "0x21dd2c18ae6c80d61ffbddaa073f7cde7bbfe9436fdf5059b506f1686326a2fb",
+          "hash": "0x21dd2c18ae6c80d61ffbddaa073f7cde7bbfe9436fdf5059b506f1686326afff",
           "timestamp": 1566346276000,
           "type": "SENT",
         },
@@ -736,14 +736,14 @@ describe('Blockscout', () => {
           "type": "SENT",
         },
         Object {
-          "account": "0x6a0edf42f5e618bee697e7718fa05efb1ea5d11c",
-          "address": "0x6a0edf42f5e618bee697e7718fa05efb1ea5d11c",
+          "account": "0x8b7649116f169d2d2aebb6ea1a77f0baf31f2811",
+          "address": "0x8b7649116f169d2d2aebb6ea1a77f0baf31f2811",
           "amount": Object {
             "currencyCode": "cUSD",
             "timestamp": 1566346276000,
             "value": "-0.15",
           },
-          "block": "90792",
+          "block": "90719",
           "comment": "",
           "fees": Array [
             Object {
@@ -763,7 +763,7 @@ describe('Blockscout', () => {
               "type": "SECURITY_FEE",
             },
           ],
-          "hash": "0x21dd2c18ae6c80d61ffbddaa073f7cde7bbfe9436fdf5059b506f1686326afff",
+          "hash": "0x21dd2c18ae6c80d61ffbddaa073f7cde7bbfe9436fdf5059b506f1686326a2fb",
           "timestamp": 1566346276000,
           "type": "SENT",
         },

--- a/packages/cloud-functions/package.json
+++ b/packages/cloud-functions/package.json
@@ -42,6 +42,6 @@
     "jest-fetch-mock": "^3.0.3"
   },
   "engines": {
-    "node": "10"
+    "node": "12"
   }
 }

--- a/packages/dev-utils/package.json
+++ b/packages/dev-utils/package.json
@@ -28,6 +28,6 @@
     "@types/targz": "1.0.0"
   },
   "engines": {
-    "node": ">=8.13.0"
+    "node": "12"
   }
 }

--- a/packages/indexer/package.json
+++ b/packages/indexer/package.json
@@ -50,7 +50,7 @@
     "@celo/flake-tracker": "0.0.1-dev"
   },
   "engines": {
-    "node": "10"
+    "node": "12"
   },
   "resolutions": {
     "web3-eth-abi/**/@ethersproject/abi": "5.0.4",

--- a/packages/komencikit/package.json
+++ b/packages/komencikit/package.json
@@ -34,7 +34,7 @@
     "web3-utils": "^1.3.0"
   },
   "engines": {
-    "node": ">=8.13.0"
+    "node": "12"
   },
   "devDependencies": {
     "domexception": "^2.0.1",

--- a/packages/moonpay-auth/package.json
+++ b/packages/moonpay-auth/package.json
@@ -23,6 +23,6 @@
     "firebase-functions-test": "^0.2.0"
   },
   "engines": {
-    "node": "10"
+    "node": "12"
   }
 }

--- a/packages/notification-service/package.json
+++ b/packages/notification-service/package.json
@@ -45,7 +45,7 @@
     "@celo/flake-tracker": "0.0.1-dev"
   },
   "engines": {
-    "node": "10"
+    "node": "12"
   },
   "resolutions": {
     "web3-eth-abi/**/@ethersproject/abi": "5.0.4",


### PR DESCRIPTION
### Description

Node 10 is end of life, therefore upgrading to 12.

### Other changes

I had to run yarn test -u to upgrade the snapshots, which is a bit worrying. Still looking into why.
Update: I am pretty sure this is caused by this change https://v8.dev/features/stable-sort, which makes array.sort stable.
I will not make any more changes to this PR but I will follow up with a new one that makes the mock timestamps unique, so we avoid this type of confusion in the future.

### Tested

This affects the app as well as these packages: notification-service, moonpay-auth, komencikit, indexer, dev-utils, cloud-functions.
Of course it's hard to make sure nothing breaks so we should proceed carefully.

### How others should test

First, people need to upgrade to node 12 locally. Something like:
`nvm install 12.22.1 && nvm use 12.22.1`

Then, just to be safe I would do a: 
`yarn reset && yarn && yarn build:wallet`

Run end to end tests:
`yarn test:e2e:android`
`yarn test:e2e:ios`

### Related issues

- Fixes #445 
