### PR TITLE
[Wallet] Update @celo/client to v1.3.2-stable

### DIFF
--- a/packages/mobile/ios/Podfile.lock
+++ b/packages/mobile/ios/Podfile.lock
@@ -4,7 +4,7 @@ PODS:
   - Adjust/Core (4.29.1)
   - Analytics (4.1.3)
   - boost-for-react-native (1.63.0)
-  - CeloBlockchain (0.0.352)
+  - CeloBlockchain (0.0.355)
   - CocoaAsyncSocket (7.6.5)
   - DoubleConversion (1.1.6)
   - FBLazyVector (0.63.4)
@@ -901,7 +901,7 @@ SPEC CHECKSUMS:
   Adjust: 5caa50e140484d30cce45085ea261144f123391c
   Analytics: 4c01e3e19d4be86705bad6581a1c2aa5a15a9d22
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
-  CeloBlockchain: a53a2bdfb7bca7e09a9ff21675e589e454f55563
+  CeloBlockchain: 0bb44b288f8fc19528d2be951e2844575d4408d4
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: cde416483dac037923206447da6e1454df403714
   FBLazyVector: 3bb422f41b18121b71783a905c10e58606f7dc3e

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -39,7 +39,7 @@
     ]
   },
   "dependencies": {
-    "@celo/client": "0.0.352",
+    "@celo/client": "0.0.355",
     "@celo/connect": "~1.2.0",
     "@celo/contractkit": "~1.2.0",
     "@celo/identity": "~1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2135,10 +2135,10 @@
   resolved "https://registry.yarnpkg.com/@celo/base/-/base-1.2.1.tgz#633ee3e8c8bcca954cad36f99718887582136f07"
   integrity sha512-xdbTV9bsmD4qLlmvtCrtcL5V4PoPYWN/VZLkSWtpgPmR7lBmlXrHXHOSALCObWm/1AxNsidOq+DNsZYRlE28SQ==
 
-"@celo/client@0.0.352":
-  version "0.0.352"
-  resolved "https://registry.yarnpkg.com/@celo/client/-/client-0.0.352.tgz#e9860a1b69916263e6bf5911a625d9924bd051f7"
-  integrity sha512-BaruxsUvFv4zm3v5DqmMzbNmcOLCBy3z49CjmYpiouQ9OOc6uNXHoozOq5QkIWK5r4lCodpH+tHHP7R1lskCUg==
+"@celo/client@0.0.355":
+  version "0.0.355"
+  resolved "https://registry.yarnpkg.com/@celo/client/-/client-0.0.355.tgz#a3ef723c94e94cef3a8a4a98cebe7ee5ce123475"
+  integrity sha512-ibdhIHi8t5+mbAUheuBW4GkFXHYxDfsorDe4MyeLa2TADor173jpV23e4Ie9N1lI6/H83azK9EHeTnxDyvItLA==
 
 "@celo/connect@1.1.0-beta.1":
   version "1.1.0-beta.1"


### PR DESCRIPTION
### Description

Update `@celo/client` to v1.3.2-stable (https://github.com/celo-org/celo-blockchain/commit/91993404cdf69ff4dad810bae8ac02763ae667d8) to address a [security issue](https://github.com/celo-org/celo-blockchain/releases/tag/v1.3.2).

### Tested

Can sync and send transaction on mainnet and alfajores.

### How others should test

- Disable "Data Saver Mode" in the settings and check the app works as expected with the blockchain (can send transactions, exchange CELO, etc).

### Related issues

- Fixes #337

### Backwards compatibility

Yes