### PR TITLE
Add vulnerability check to GitHub Actions

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -9,6 +9,18 @@ on:
   pull_request:
 
 jobs:
+  vulnerability:
+    name: Vulnerability
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '12'
+          check-latest: true
+      - run: yarn
+      - run: yarn build --ignore docs
+      - run: ./scripts/ci_check_vulnerabilities.sh
   lint:
     name: Lint
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description

This PR implements the vulnerability check from CircleCI to GitHub Actions. Later PR will implement caching and other optimizations. 

### Tested

This is replacing the CircleCI config. As long as it does the same thing and passes it doesn't need to be tested further.


### How others should test

No testing needed, just need to verify it passes.

### Related issues

- Implements #522.

### Backwards compatibility

GitHub Actions will be replacing CircleCI.