### PR TITLE
Add cEUR transfer support to notification service

### DIFF
--- a/packages/notification-service/app.alfajores.yaml
+++ b/packages/notification-service/app.alfajores.yaml
@@ -1,4 +1,4 @@
-runtime: nodejs10
+runtime: nodejs12
 service: notification
 instance_class: B4
 manual_scaling:

--- a/packages/notification-service/app.mainnet.yaml
+++ b/packages/notification-service/app.mainnet.yaml
@@ -1,4 +1,4 @@
-runtime: nodejs10
+runtime: nodejs12
 service: notification
 instance_class: B4
 manual_scaling:

--- a/packages/notification-service/locales/en.json
+++ b/packages/notification-service/locales/en.json
@@ -5,6 +5,8 @@
   "celoReceivedBody": "You just received {{amount}} CELO! You can earn, save and spend in Valora. Tap to learn more.",
   "dollar": "Celo Dollar",
   "dollar_plural": "Celo Dollars",
+  "euro": "Celo Euro",
+  "euro_plural": "Celo Euros",
   "gold": "CELO",
   "paymentRequestedTitle": "Payment Requested",
   "paymentRequestedBody": "Payment of {{amount}} {{currency}} has been requested",

--- a/packages/notification-service/src/blockscout/transfers.ts
+++ b/packages/notification-service/src/blockscout/transfers.ts
@@ -59,11 +59,11 @@ async function getLatestTokenTransfers(
   }
 
   if (!response.result.length) {
-    console.debug('No new logs found for token:', currency)
+    console.debug('No new logs found for token:', currency, tokenAddress)
     return { transfers: null, latestBlock: lastBlockNotified }
   }
 
-  console.debug('New logs found for token:', currency, response.result.length)
+  console.debug('New logs found for token:', currency, tokenAddress, response.result.length)
   const { transfers, latestBlock } = formatTransfers(response.result as TokenTransfer[], currency)
   return { transfers, latestBlock }
 }
@@ -83,7 +83,7 @@ export function filterAndJoinTransfers(
   )
   const filteredCusd = cUsdTransfers.filter((t) => !celoTransfersByTx?.has(t.txHash))
   const filteredCEur = cEurTransfers.filter((t) => !celoTransfersByTx?.has(t.txHash))
-  return filteredCelo.concat(filteredCusd).concat(filteredCEur)
+  return filteredCelo.concat(filteredCusd, filteredCEur)
 }
 
 export function notifyForNewTransfers(transfers: Transfer[]): Promise<void[]> {
@@ -168,7 +168,7 @@ export async function handleTransferNotifications(): Promise<void> {
 
   const allTransfers = filterAndJoinTransfers(celoTransfers, cUsdTransfers, cEurTransfers)
   const newCheckpointBlock = setLastBlockNotified(
-    Math.max(Math.max(cUsdTransfersLatestBlock, celoTransfersLatestBlock), cEurTransfersLatestBlock)
+    Math.max(cUsdTransfersLatestBlock, celoTransfersLatestBlock, cEurTransfersLatestBlock)
   )
   await notifyForNewTransfers(allTransfers)
   updateProcessedBlocks(celoTransfers, Currencies.GOLD, celoTransfersLatestBlock)

--- a/packages/notification-service/src/firebase.ts
+++ b/packages/notification-service/src/firebase.ts
@@ -199,6 +199,10 @@ function notificationTitleAndBody(senderAddress: string, currency: Currencies) {
       title: 'paymentReceivedTitle',
       body: 'paymentReceivedBody',
     },
+    [Currencies.EURO]: {
+      title: 'paymentReceivedTitle',
+      body: 'paymentReceivedBody',
+    },
     [Currencies.GOLD]: {
       title: 'celoReceivedTitle',
       body: 'celoReceivedBody',

--- a/packages/notification-service/src/util/utils.ts
+++ b/packages/notification-service/src/util/utils.ts
@@ -21,15 +21,17 @@ export function removeEmptyValuesFromObject(obj: ObjectWithStringsAndUndefined) 
 }
 
 let goldTokenAddress: string
-let stableTokenAddress: string
+let cUsdTokenAddress: string
+let cEurTokenAddress: string
 export async function getTokenAddresses() {
-  if (goldTokenAddress && stableTokenAddress) {
-    return { goldTokenAddress, stableTokenAddress }
+  if (goldTokenAddress && cUsdTokenAddress && cEurTokenAddress) {
+    return { goldTokenAddress, cUsdTokenAddress, cEurTokenAddress }
   } else {
     const kit = await getContractKit()
     goldTokenAddress = await kit.registry.addressFor(CeloContract.GoldToken)
-    stableTokenAddress = await kit.registry.addressFor(CeloContract.StableToken)
-    return { goldTokenAddress, stableTokenAddress }
+    cUsdTokenAddress = await kit.registry.addressFor(CeloContract.StableToken)
+    cEurTokenAddress = await kit.registry.addressFor(CeloContract.StableTokenEUR)
+    return { goldTokenAddress, cUsdTokenAddress, cEurTokenAddress }
   }
 }
 

--- a/packages/notification-service/test/transfers.test.ts
+++ b/packages/notification-service/test/transfers.test.ts
@@ -18,6 +18,15 @@ const DOLLAR_TRANSFER = {
   currency: Currencies.DOLLAR,
   timestamp: 1,
 }
+const EURO_TRANSFER = {
+  recipient: 'euro-recipient',
+  sender: 'euro-sender',
+  value: '2',
+  blockNumber: 155,
+  txHash: 'euro-txhash',
+  currency: Currencies.EURO,
+  timestamp: 1,
+}
 const DOLLAR_EXCHANGE = {
   recipient: 'recipient',
   sender: 'sender',
@@ -25,6 +34,15 @@ const DOLLAR_EXCHANGE = {
   blockNumber: 154,
   txHash: 'exchange-txhash',
   currency: Currencies.DOLLAR,
+  timestamp: 2,
+}
+const EURO_EXCHANGE = {
+  recipient: 'recipient',
+  sender: 'sender',
+  value: '10',
+  blockNumber: 154,
+  txHash: 'exchange-txhash',
+  currency: Currencies.EURO,
   timestamp: 2,
 }
 const CELO_TRANSFER = {
@@ -76,6 +94,7 @@ jest.mock('../src/blockscout/transfersFormatter', () => {
     .fn()
     .mockReturnValueOnce({ transfers: [], latestBlock: 156 })
     .mockReturnValueOnce({ transfers: [], latestBlock: 154 })
+    .mockReturnValueOnce({ transfers: [], latestBlock: 154 })
 
   return {
     formatTransfers: transfersFormatterMock,
@@ -116,30 +135,34 @@ describe('Transfers', () => {
 
   it('should exclude exchanges', () => {
     const celoTransfers = new Map<string, Transfer[]>()
-    const stableTransfers = new Map<string, Transfer[]>()
+    const cUsdTransfers = new Map<string, Transfer[]>()
+    const cEurTransfers = new Map<string, Transfer[]>()
 
     celoTransfers.set(CELO_EXCHANGE.txHash, [CELO_EXCHANGE])
-    stableTransfers.set(DOLLAR_EXCHANGE.txHash, [DOLLAR_EXCHANGE])
+    cUsdTransfers.set(DOLLAR_EXCHANGE.txHash, [DOLLAR_EXCHANGE])
+    cEurTransfers.set(DOLLAR_EXCHANGE.txHash, [EURO_EXCHANGE])
 
-    const concated = filterAndJoinTransfers(celoTransfers, stableTransfers)
+    const concated = filterAndJoinTransfers(celoTransfers, cUsdTransfers, cEurTransfers)
 
     expect(concated).toEqual([])
   })
 
   it('should include unique transactions and update the last block', () => {
     const celoTransfers = new Map<string, Transfer[]>()
-    const stableTransfers = new Map<string, Transfer[]>()
+    const cUsdTransfers = new Map<string, Transfer[]>()
+    const cEurTransfers = new Map<string, Transfer[]>()
 
     celoTransfers.set(CELO_TRANSFER.txHash, [CELO_TRANSFER])
-    stableTransfers.set(DOLLAR_TRANSFER.txHash, [DOLLAR_TRANSFER])
+    cUsdTransfers.set(DOLLAR_TRANSFER.txHash, [DOLLAR_TRANSFER])
+    cEurTransfers.set(EURO_TRANSFER.txHash, [EURO_TRANSFER])
 
-    const concated = filterAndJoinTransfers(celoTransfers, stableTransfers)
+    const concated = filterAndJoinTransfers(celoTransfers, cUsdTransfers, cEurTransfers)
 
-    expect(concated).toEqual([CELO_TRANSFER, DOLLAR_TRANSFER])
+    expect(concated).toEqual([CELO_TRANSFER, DOLLAR_TRANSFER, EURO_TRANSFER])
   })
 
   it('should notify for new transfers since last block notified', async () => {
-    const transfers = [CELO_TRANSFER, DOLLAR_TRANSFER]
+    const transfers = [CELO_TRANSFER, DOLLAR_TRANSFER, EURO_TRANSFER]
     const returned = await notifyForNewTransfers(transfers)
 
     expect(sendPaymentNotificationMock).toHaveBeenCalledWith(

--- a/packages/notification-service/test/transfers.test.ts
+++ b/packages/notification-service/test/transfers.test.ts
@@ -190,6 +190,19 @@ describe('Transfers', () => {
         timestamp: String(DOLLAR_TRANSFER.timestamp),
       }
     )
+
+    expect(sendPaymentNotificationMock).toHaveBeenCalledWith(
+      EURO_TRANSFER.sender,
+      EURO_TRANSFER.recipient,
+      convertWeiValue(EURO_TRANSFER.value),
+      EURO_TRANSFER.currency,
+      EURO_TRANSFER.blockNumber,
+      {
+        ...EURO_TRANSFER,
+        blockNumber: String(EURO_TRANSFER.blockNumber),
+        timestamp: String(EURO_TRANSFER.timestamp),
+      }
+    )
     expect(returned.length).toEqual(transfers.length)
   })
 


### PR DESCRIPTION
### Description

Added cEUR support to the notification service so that a notification is sent when a cEUR transfer is made.

### Other changes

Updated the node env to 12.

### Tested

Manually using two phones.

### How others should test

Send cEUR to another device. Check that you receive a push notification in the recipient's device.

### Related issues

- Fixes #652

### Backwards compatibility

N/A