### PR TITLE
Update text on rewards screen

### DIFF
--- a/packages/mobile/locales/en-US/consumerIncentives.json
+++ b/packages/mobile/locales/en-US/consumerIncentives.json
@@ -1,6 +1,6 @@
 {
   "title": "A new way to earn",
-  "summary": "Starting {{date}}, you’ll earn {{percent}}% annually on your cUSD balance.",
+  "summary": "Starting now, you’ll earn up to {{percent}}% annually on your cUSD balance.",
   "earnWeekly": {
     "header": "Earn Weekly",
     "text": "Send and spend as usual, you’ll earn on the remaining balance."

--- a/packages/mobile/src/consumerIncentives/ConsumerIncentivesHomeScreen.tsx
+++ b/packages/mobile/src/consumerIncentives/ConsumerIncentivesHomeScreen.tsx
@@ -28,11 +28,7 @@ export default function ConsumerIncentivesHomeScreen(props: Props) {
   const userIsVerified = useSelector((state) => state.app.numberVerified)
   const insets = useSafeAreaInsets()
 
-  const { rewardsPercent, rewardsStartDate, rewardsMax } = useSelector((state) => state.app)
-  const startDate = new Date(rewardsStartDate).toLocaleDateString(undefined, {
-    month: 'long',
-    day: 'numeric',
-  })
+  const { rewardsPercent, rewardsMax } = useSelector((state) => state.app)
   const maxSaving = (rewardsPercent / 100) * rewardsMax
 
   const onPressCTA = () => {
@@ -64,9 +60,7 @@ export default function ConsumerIncentivesHomeScreen(props: Props) {
         </Touchable>
         <Image source={earnMain} />
         <Text style={styles.title}>{t('title')}</Text>
-        <Text style={styles.description}>
-          {t('summary', { date: startDate, percent: rewardsPercent })}
-        </Text>
+        <Text style={styles.description}>{t('summary', { percent: rewardsPercent })}</Text>
         <View style={styles.section}>
           <Image source={earn1} style={styles.sectionImage} resizeMode="contain" />
           <View style={styles.sectionText}>


### PR DESCRIPTION
### Description

From the issue description:
```
https://github.com/celo-org/wallet/blob/main/packages/mobile/locales/en-US/consumerIncentives.json#L3
should say

"summary": "Starting now, you’ll earn up to {{percent}}% annually on your cUSD balance.",

instead of
"summary": "Starting {{date}}, you’ll earn {{percent}}% annually on your cUSD balance.",
```
<img width="359" alt="Screen Shot 2021-07-01 at 16 59 45" src="https://user-images.githubusercontent.com/6062888/124182810-c0833400-da8d-11eb-8be4-f29e10f5d5f9.png">

### Other changes

N/A

### Tested

Manually (See screenshot)

### How others should test

Check that the correct text shows up in the rewards screen

### Related issues

- Fixes #https://github.com/celo-org/celo-monorepo/issues/8197

### Backwards compatibility

N/A
