### PR TITLE
Show more decimals in feed for values lower than 0.01

### DIFF
--- a/packages/mobile/src/account/__snapshots__/FiatExchange.test.tsx.snap
+++ b/packages/mobile/src/account/__snapshots__/FiatExchange.test.tsx.snap
@@ -141,8 +141,9 @@ exports[`FiatExchange renders correctly 1`] = `
         testID="undefined/value"
       >
         
+        &lt;
         $
-        0.00
+        0.001
       </Text>
     </View>
     <Image

--- a/packages/mobile/src/components/CurrencyDisplay.tsx
+++ b/packages/mobile/src/components/CurrencyDisplay.tsx
@@ -157,6 +157,7 @@ export default function CurrencyDisplay({
   const formatAmount = getFormatFunction(formatType)
   const formattedValue =
     value && displayCurrency ? formatAmount(value.absoluteValue(), displayCurrency) : '-'
+  const includesLowerThanSymbol = formattedValue.startsWith('<')
   const code = displayAmount?.currencyCode
   const fullCurrencyName = getFullCurrencyName(amountCurrency)
 
@@ -192,13 +193,18 @@ export default function CurrencyDisplay({
             {sign}
           </Text>
         )}
+        {includesLowerThanSymbol && (
+          <Text numberOfLines={1} style={[fontStyles.regular, symbolStyle]}>
+            {'<'}
+          </Text>
+        )}
         {!hideSymbol && (
           <Text numberOfLines={1} style={[fontStyles.regular, symbolStyle]}>
             {currencySymbol}
           </Text>
         )}
         <Text numberOfLines={1} style={[styles.bigCurrency, amountStyle]}>
-          {formattedValue}
+          {formattedValue.substring(includesLowerThanSymbol ? 1 : 0)}
         </Text>
         {!hideCode && !!code && (
           <Text numberOfLines={1} style={[styles.bigCurrencyCode, codeStyle]}>
@@ -212,8 +218,9 @@ export default function CurrencyDisplay({
   return (
     <Text numberOfLines={1} style={[style, { color }]} testID={`${testID}/value`}>
       {!hideSign && sign}
+      {includesLowerThanSymbol && '<'}
       {!hideSymbol && currencySymbol}
-      {formattedValue}
+      {formattedValue.substring(includesLowerThanSymbol ? 1 : 0)}
       {!hideCode && !!code && ` ${code}`}
       {!hideFullCurrencyName && !!fullCurrencyName && ` ${fullCurrencyName}`}
     </Text>

--- a/packages/mobile/src/escrow/__snapshots__/EscrowedPaymentListItem.test.tsx.snap
+++ b/packages/mobile/src/escrow/__snapshots__/EscrowedPaymentListItem.test.tsx.snap
@@ -95,8 +95,9 @@ exports[`EscrowedPaymentReminderNotification renders correctly 1`] = `
             testID="undefined/value"
           >
             
+            &lt;
             $
-            0.00
+            0.001
           </Text>
         </Text>
         <Text

--- a/packages/mobile/src/exchange/__snapshots__/ExchangeTradeScreen.test.tsx.snap
+++ b/packages/mobile/src/exchange/__snapshots__/ExchangeTradeScreen.test.tsx.snap
@@ -332,8 +332,9 @@ exports[`ExchangeTradeScreen renders correctly 1`] = `
             testID="undefined/value"
           >
             
+            &lt;
             $
-            0.00
+            0.001
           </Text>
         </Text>
       </View>

--- a/packages/mobile/src/fiatExchanges/__snapshots__/FiatExchangeAmount.test.tsx.snap
+++ b/packages/mobile/src/fiatExchanges/__snapshots__/FiatExchangeAmount.test.tsx.snap
@@ -585,7 +585,8 @@ exports[`FiatExchangeAmount cashIn renders correctly 1`] = `
             testID="undefined/value"
           >
             
-            0.00
+            &lt;
+            0.001
           </Text>
         </Text>
       </View>

--- a/packages/mobile/src/import/__snapshots__/ImportWallet.test.tsx.snap
+++ b/packages/mobile/src/import/__snapshots__/ImportWallet.test.tsx.snap
@@ -403,8 +403,9 @@ exports[`ImportWallet renders correctly and is disabled with no text 1`] = `
                   testID="undefined/value"
                 >
                   
+                  &lt;
                   $
-                  0.00
+                  0.001
                 </Text>
               </Text>
               <Text

--- a/packages/mobile/src/send/SendConfirmation.test.tsx
+++ b/packages/mobile/src/send/SendConfirmation.test.tsx
@@ -3,7 +3,6 @@ import BigNumber from 'bignumber.js'
 import * as React from 'react'
 import { fireEvent, flushMicrotasksQueue, render } from 'react-native-testing-library'
 import { Provider } from 'react-redux'
-import { ReactTestInstance } from 'react-test-renderer'
 import { ErrorDisplayType } from 'src/alert/reducer'
 import { SendOrigin } from 'src/analytics/types'
 import { ErrorMessages } from 'src/app/ErrorMessages'
@@ -15,7 +14,12 @@ import { RootState } from 'src/redux/reducers'
 import { getSendFee } from 'src/send/saga'
 import SendConfirmation from 'src/send/SendConfirmation'
 import { Currency } from 'src/utils/currencies'
-import { createMockStore, getMockStackScreenProps, RecursivePartial } from 'test/utils'
+import {
+  amountFromComponent,
+  createMockStore,
+  getMockStackScreenProps,
+  RecursivePartial,
+} from 'test/utils'
 import {
   mockAccount2Invite,
   mockAccountInvite,
@@ -86,10 +90,6 @@ describe('SendConfirmation', () => {
       store,
       ...tree,
     }
-  }
-
-  function amountFromComponent(component: ReactTestInstance) {
-    return component.props.children.filter((child: any) => typeof child === 'string').join('')
   }
 
   it('renders correctly', async () => {

--- a/packages/mobile/src/transactions/TransactionFeedItem.tsx
+++ b/packages/mobile/src/transactions/TransactionFeedItem.tsx
@@ -50,6 +50,7 @@ export function TransactionFeedItem(props: Props) {
               showExplicitPositiveSign={true}
               hideFullCurrencyName={!isCeloTx}
               style={[styles.amount, isReceived && styles.amountReceived]}
+              testID={'FeedItemAmountDisplay'}
             />
           </View>
           {!!subtitle && <Text style={styles.subtitle}>{subtitle}</Text>}

--- a/packages/mobile/src/transactions/TransferFeedItem.test.tsx
+++ b/packages/mobile/src/transactions/TransferFeedItem.test.tsx
@@ -7,7 +7,7 @@ import { TokenTransactionType } from 'src/apollo/types'
 import { RecipientInfo } from 'src/recipients/recipient'
 import { TransferFeedItem } from 'src/transactions/TransferFeedItem'
 import { TransactionStatus } from 'src/transactions/types'
-import { createMockStore, getMockI18nProps } from 'test/utils'
+import { amountFromComponent, createMockStore, getMockI18nProps } from 'test/utils'
 import {
   mockAccount,
   mockAccount2,
@@ -499,5 +499,57 @@ describe('transfer feed item renders correctly', () => {
     )
     expect(tree.queryByText(contactName)).toBeFalsy()
     expect(tree.queryByText(mockE164Number)).toBeTruthy()
+  })
+  it('for received with a value between 0.01 and 0.001', () => {
+    const { getByTestId } = render(
+      <Provider store={mockStore}>
+        <TransferFeedItem
+          __typename="TokenTransfer"
+          status={TransactionStatus.Complete}
+          comment={''}
+          type={TokenTransactionType.Received}
+          hash={'0x'}
+          amount={{ value: '0.006', currencyCode: 'cUSD', localAmount: null }}
+          address={mockAccount}
+          timestamp={1}
+          commentKey={null}
+          addressToE164Number={{}}
+          phoneRecipientCache={mockPhoneRecipientCache}
+          recipientInfo={mockRecipientInfo}
+          recentTxRecipientsCache={{}}
+          invitees={[]}
+          account={''}
+          {...getMockI18nProps()}
+        />
+      </Provider>
+    )
+    const amountComponent = getByTestId('FeedItemAmountDisplay/value')
+    expect(amountFromComponent(amountComponent)).toEqual('+$0.008')
+  })
+  it('for received with a value lower than 0.001', () => {
+    const { getByTestId } = render(
+      <Provider store={mockStore}>
+        <TransferFeedItem
+          __typename="TokenTransfer"
+          status={TransactionStatus.Complete}
+          comment={''}
+          type={TokenTransactionType.Received}
+          hash={'0x'}
+          amount={{ value: '0.0006', currencyCode: 'cUSD', localAmount: null }}
+          address={mockAccount}
+          timestamp={1}
+          commentKey={null}
+          addressToE164Number={{}}
+          phoneRecipientCache={mockPhoneRecipientCache}
+          recipientInfo={mockRecipientInfo}
+          recentTxRecipientsCache={{}}
+          invitees={[]}
+          account={''}
+          {...getMockI18nProps()}
+        />
+      </Provider>
+    )
+    const amountComponent = getByTestId('FeedItemAmountDisplay/value')
+    expect(amountFromComponent(amountComponent)).toEqual('+<$0.001')
   })
 })

--- a/packages/mobile/src/transactions/__snapshots__/TransferFeedItem.test.tsx.snap
+++ b/packages/mobile/src/transactions/__snapshots__/TransferFeedItem.test.tsx.snap
@@ -105,8 +105,9 @@ exports[`transfer feed item renders correctly for <0.000001 network fee 1`] = `
           testID="undefined/value"
         >
           -
+          &lt;
           $
-          &lt;0.001
+          0.001
         </Text>
       </View>
       <Text

--- a/packages/mobile/src/utils/formatting.ts
+++ b/packages/mobile/src/utils/formatting.ts
@@ -13,7 +13,15 @@ export const getMoneyDisplayValue = (
 ): string => {
   const decimals = CURRENCIES[currency].displayDecimals
   const symbol = CURRENCIES[currency].symbol
-  const formattedValue = roundDown(value, decimals, roundingTolerance).toFormat(decimals)
+  // For stable currencies, if the value is lower than 0.01 we show an extra decimal point.
+  // If the value is lower than 0.001, we just show <$0.001.
+  const minValueToShow = Math.pow(10, -decimals - (currency === Currency.Celo ? 0 : 1))
+  if (value < minValueToShow) {
+    return `<${includeSymbol ? symbol : ''}${minValueToShow}`
+  }
+  const decimalsToUse =
+    currency === Currency.Celo || value >= Math.pow(10, -decimals) ? decimals : decimals + 1
+  const formattedValue = roundDown(value, decimalsToUse, roundingTolerance).toFormat(decimalsToUse)
   return includeSymbol ? symbol + formattedValue : formattedValue
 }
 

--- a/packages/mobile/test/utils.ts
+++ b/packages/mobile/test/utils.ts
@@ -167,3 +167,7 @@ export function getElementText(instance: ReactTestInstance | string): string {
     })
     .join('')
 }
+
+export function amountFromComponent(component: ReactTestInstance) {
+  return component.props.children.filter((child: any) => typeof child === 'string').join('')
+}


### PR DESCRIPTION
### Description

Changed the behavior of `CurrencyDisplay` so that it can show an extra decimal if the amount is lower than 0.01 for stable currencies.

The rules for this are [in this Figma file](https://www.figma.com/file/31HUGhIHLXEm1qwVpHV1QR/CELO-Rewards?node-id=1401%3A45988), copying here for simplicity:
```
Rewards under $0.01:
We can expand to three decimal places if the reward is less than $0.01. 
If the amount is below $0.001, then display “+<$0.001”.

Note: It would be ideal to apply this scheme to all transaction amounts in the Home Feed. We currently show $0.00 for small amounts.
```

<img width="359" alt="Screen Shot 2021-07-01 at 17 57 44" src="https://user-images.githubusercontent.com/6062888/124190685-10b3c380-da99-11eb-9c8b-59a25b3a0257.png">

### Other changes

N/A

### Tested

Added unit test and manually (see screenshot)

### How others should test

Make transactions to yourself for values between 0.01 and 0.001 and for values lower than 0.001 and see that the expected behavior is observed. To do this, one option is to make a transfer for $0.01 and then change the local currency to something like PHP which has less decimal places.

### Related issues

- Fixes #https://github.com/celo-org/celo-monorepo/issues/8039

### Backwards compatibility

N/A