### PR TITLE
Fix crash due to redux immutability

### DIFF
--- a/packages/mobile/src/transactions/transferFeedUtils.ts
+++ b/packages/mobile/src/transactions/transferFeedUtils.ts
@@ -77,7 +77,7 @@ function getRecipient(
       : recentTxRecipientsCache[phoneNumber]
 
     if (recipient) {
-      return recipient
+      return { ...recipient }
     } else {
       recipient = { e164PhoneNumber: phoneNumber }
       return recipient


### PR DESCRIPTION
### Description

This change is fixing this crash:
https://sentry.io/organizations/celo/issues/2499735012/?project=1250733&query=is%3Aunresolved

The crash was introduced on this PR: https://github.com/celo-org/wallet/pull/656 when switching to redux toolkit. The new toolkit uses `immer` under the hood which makes the objects immutable and  we were using Object.assign in some places 

### Other changes

N/A

### Tested

Manually

### How others should test

Use the app to send to some people so that the recipients cache is populated and then just try to send to someone. The app should never crash.

### Related issues

- Fixes #837

### Backwards compatibility

N/A