### PR TITLE
[BlockchainApi] Fix feed error when local currency is EUR

### DIFF
--- a/packages/blockchain-api/src/currencyConversion/CurrencyConversionAPI.test.ts
+++ b/packages/blockchain-api/src/currencyConversion/CurrencyConversionAPI.test.ts
@@ -146,8 +146,14 @@ describe('CurrencyConversionAPI', () => {
     })
     expect(result).toEqual(new BigNumber(200))
 
-    expect(mockDefaultGetExchangeRate).toHaveBeenCalledTimes(1)
-    expect(mockGoldGetExchangeRate).toHaveBeenCalledTimes(1)
+    expect(mockGoldGetExchangeRate).toHaveBeenCalledWith({
+      sourceCurrencyCode: 'cGLD',
+      currencyCode: 'cUSD',
+    })
+    expect(mockDefaultGetExchangeRate).toHaveBeenCalledWith({
+      sourceCurrencyCode: 'USD',
+      currencyCode: 'EUR',
+    })
   })
 
   it('should retrieve rate for EUR/cGLD', async () => {
@@ -156,7 +162,14 @@ describe('CurrencyConversionAPI', () => {
       currencyCode: 'cGLD',
     })
     expect(result).toEqual(new BigNumber(200))
-    expect(mockDefaultGetExchangeRate).toHaveBeenCalledTimes(1)
-    expect(mockGoldGetExchangeRate).toHaveBeenCalledTimes(1)
+
+    expect(mockDefaultGetExchangeRate).toHaveBeenCalledWith({
+      sourceCurrencyCode: 'EUR',
+      currencyCode: 'USD',
+    })
+    expect(mockGoldGetExchangeRate).toHaveBeenCalledWith({
+      sourceCurrencyCode: 'cUSD',
+      currencyCode: 'cGLD',
+    })
   })
 })

--- a/packages/blockchain-api/src/currencyConversion/CurrencyConversionAPI.test.ts
+++ b/packages/blockchain-api/src/currencyConversion/CurrencyConversionAPI.test.ts
@@ -140,16 +140,14 @@ describe('CurrencyConversionAPI', () => {
   })
 
   it('should retrieve rate for cGLD/EUR', async () => {
-    const impliedExchangeRates = { 'cGLD/cEUR': new BigNumber(10) }
     const result = await currencyConversionAPI.getExchangeRate({
       sourceCurrencyCode: 'cGLD',
       currencyCode: 'EUR',
-      impliedExchangeRates,
     })
-    expect(result).toEqual(new BigNumber(10))
+    expect(result).toEqual(new BigNumber(200))
 
-    expect(mockDefaultGetExchangeRate).toHaveBeenCalledTimes(0)
-    expect(mockGoldGetExchangeRate).toHaveBeenCalledTimes(0)
+    expect(mockDefaultGetExchangeRate).toHaveBeenCalledTimes(1)
+    expect(mockGoldGetExchangeRate).toHaveBeenCalledTimes(1)
   })
 
   it('should retrieve rate for EUR/cGLD', async () => {
@@ -157,8 +155,8 @@ describe('CurrencyConversionAPI', () => {
       sourceCurrencyCode: 'EUR',
       currencyCode: 'cGLD',
     })
-    expect(result).toEqual(new BigNumber(10))
-    expect(mockDefaultGetExchangeRate).toHaveBeenCalledTimes(0)
+    expect(result).toEqual(new BigNumber(200))
+    expect(mockDefaultGetExchangeRate).toHaveBeenCalledTimes(1)
     expect(mockGoldGetExchangeRate).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/blockchain-api/src/currencyConversion/CurrencyConversionAPI.ts
+++ b/packages/blockchain-api/src/currencyConversion/CurrencyConversionAPI.ts
@@ -1,15 +1,7 @@
 import { DataSource, DataSourceConfig } from 'apollo-datasource'
 import BigNumber from 'bignumber.js'
 import { CurrencyConversionArgs, MoneyAmount } from '../schema'
-import {
-  CGLD,
-  CUSD,
-  stablePairs,
-  supportedCurrencies,
-  supportedPairs,
-  supportedStableTokens,
-  USD,
-} from './consts'
+import { CGLD, CUSD, stablePairs, supportedPairs, supportedStableTokens, USD } from './consts'
 import ExchangeRateAPI from './ExchangeRateAPI'
 import GoldExchangeRateAPI from './GoldExchangeRateAPI'
 
@@ -60,9 +52,6 @@ export default class CurrencyConversionAPI<TContext = any> extends DataSource {
     } else if (fromCode === CGLD || toCode === CGLD) {
       // cGLD -> X (where X !== celoStableToken)
       if (fromCode === CGLD && !this.enumContains(supportedStableTokens, toCode.toUpperCase())) {
-        if (this.enumContains(supportedCurrencies, toCode) && toCode !== USD) {
-          return [CGLD, this.getStableToken(toCode), toCode]
-        }
         return [CGLD, CUSD, ...insertIf(toCode !== USD, USD), toCode]
       }
       // Currency -> cGLD (where X !== celoStableToken)
@@ -70,9 +59,6 @@ export default class CurrencyConversionAPI<TContext = any> extends DataSource {
         !this.enumContains(supportedStableTokens, fromCode.toUpperCase()) &&
         toCode === CGLD
       ) {
-        if (this.enumContains(supportedCurrencies, fromCode) && fromCode !== USD) {
-          return [fromCode, this.getStableToken(fromCode), CGLD]
-        }
         return [fromCode, ...insertIf(fromCode !== USD, USD), CUSD, CGLD]
       }
     } else {
@@ -99,10 +85,6 @@ export default class CurrencyConversionAPI<TContext = any> extends DataSource {
 
   private enumContains(x: any, code: string) {
     return Object.values(x).includes(code)
-  }
-
-  private getStableToken(code: string) {
-    return 'c' + code
   }
 
   private getCurrency(code: string) {

--- a/packages/blockchain-api/src/currencyConversion/CurrencyConversionAPI.ts
+++ b/packages/blockchain-api/src/currencyConversion/CurrencyConversionAPI.ts
@@ -52,6 +52,8 @@ export default class CurrencyConversionAPI<TContext = any> extends DataSource {
     } else if (fromCode === CGLD || toCode === CGLD) {
       // cGLD -> X (where X !== celoStableToken)
       if (fromCode === CGLD && !this.enumContains(supportedStableTokens, toCode.toUpperCase())) {
+        // TODO, we could optimize this and use the cGLD/cEUR rate for instance
+        // but it would only be supported from the date when we started storing it
         return [CGLD, CUSD, ...insertIf(toCode !== USD, USD), toCode]
       }
       // Currency -> cGLD (where X !== celoStableToken)
@@ -59,6 +61,8 @@ export default class CurrencyConversionAPI<TContext = any> extends DataSource {
         !this.enumContains(supportedStableTokens, fromCode.toUpperCase()) &&
         toCode === CGLD
       ) {
+        // TODO, we could optimize this and use the cEUR/cGLD rate for instance
+        // but it would only be supported from the date when we started storing it
         return [fromCode, ...insertIf(fromCode !== USD, USD), CUSD, CGLD]
       }
     } else {


### PR DESCRIPTION
### Description

Fixed regression introduced in #259 causing Valora clients to get an error loading their transaction feed when the local currency is set to `EUR` and they have `CELO` transactions in their history that were done before May.

Specifically, when converting from `EUR` to `CELO` (or vice versa), it tried to use the `cEUR/cGLD` (or `cGLD/cEUR`) rate we store in firebase.
However we only have data for these pairs since May or so, and hence can't use that for `EUR` to `CELO` prior to that date.

The fix implemented here is simple. An improvement would be to check the requested timestamp to determine whether we can use the `cEUR/cGLD` (or `cGLD/cEUR`) rate or fallback to the current fix.

### Tested

Tested on Alfajores.

### How others should test

Have some `CELO` transactions in your feed created before May and local currency set to `EUR`, check that the feeds load properly.

### Related issues

[Thread on Slack](https://valora-app.slack.com/archives/CL7BVQPHB/p1625690953274500)

### Backwards compatibility

Yes