### PR TITLE
Hide keyboard when selecting currency to exchange

### DIFF
--- a/packages/mobile/src/exchange/ExchangeScreenHeader.tsx
+++ b/packages/mobile/src/exchange/ExchangeScreenHeader.tsx
@@ -2,7 +2,7 @@ import Touchable from '@celo/react-components/components/Touchable'
 import DownArrowIcon from '@celo/react-components/icons/DownArrowIcon'
 import colors from '@celo/react-components/styles/colors'
 import React, { useMemo, useState } from 'react'
-import { StyleSheet, Text, View } from 'react-native'
+import { Keyboard, StyleSheet, Text, View } from 'react-native'
 import { CeloExchangeEvents } from 'src/analytics/Events'
 import CancelButton from 'src/components/CancelButton'
 import CustomHeader from 'src/components/header/CustomHeader'
@@ -56,8 +56,13 @@ function ExchangeTradeScreenHeader({ currency, makerToken, onChangeCurrency }: P
       )
     }
 
+    const showTokenPicker = () => {
+      setShowTokenPicker(true)
+      Keyboard.dismiss()
+    }
+
     return (
-      <Touchable disabled={singleTokenAvailable} onPress={() => setShowTokenPicker(true)}>
+      <Touchable disabled={singleTokenAvailable} onPress={showTokenPicker}>
         <HeaderTitleWithBalance title={title} token={currency} switchTitleAndSubtitle={true} />
       </Touchable>
     )


### PR DESCRIPTION
### Description

Fix for this issue found by QA: https://github.com/celo-org/wallet/issues/851

In short, in the exchange amount screen, when a user has the keyboard open to input an amount and they tap on the header the balance picker was showing below the keyboard. We're now hiding the keyboard when the header is tapped.

### Other changes

N/A

### Tested

On iOS and Android

### How others should test

Go to the exchange screen and try to change the currency to do the exchange with. The keyboard should close when tapping on the header.

### Related issues

- Fixes #851

### Backwards compatibility

N/A