### PR TITLE
Show 0.00 instead of <0.000 when an amount is exactly 0

### DIFF
--- a/packages/mobile/src/account/__snapshots__/FiatExchange.test.tsx.snap
+++ b/packages/mobile/src/account/__snapshots__/FiatExchange.test.tsx.snap
@@ -141,9 +141,8 @@ exports[`FiatExchange renders correctly 1`] = `
         testID="undefined/value"
       >
         
-        &lt;
         $
-        0.001
+        0.00
       </Text>
     </View>
     <Image

--- a/packages/mobile/src/exchange/__snapshots__/ExchangeTradeScreen.test.tsx.snap
+++ b/packages/mobile/src/exchange/__snapshots__/ExchangeTradeScreen.test.tsx.snap
@@ -332,9 +332,8 @@ exports[`ExchangeTradeScreen renders correctly 1`] = `
             testID="undefined/value"
           >
             
-            &lt;
             $
-            0.001
+            0.00
           </Text>
         </Text>
       </View>

--- a/packages/mobile/src/fiatExchanges/__snapshots__/FiatExchangeAmount.test.tsx.snap
+++ b/packages/mobile/src/fiatExchanges/__snapshots__/FiatExchangeAmount.test.tsx.snap
@@ -585,8 +585,7 @@ exports[`FiatExchangeAmount cashIn renders correctly 1`] = `
             testID="undefined/value"
           >
             
-            &lt;
-            0.001
+            0.00
           </Text>
         </Text>
       </View>

--- a/packages/mobile/src/import/__snapshots__/ImportWallet.test.tsx.snap
+++ b/packages/mobile/src/import/__snapshots__/ImportWallet.test.tsx.snap
@@ -403,9 +403,8 @@ exports[`ImportWallet renders correctly and is disabled with no text 1`] = `
                   testID="undefined/value"
                 >
                   
-                  &lt;
                   $
-                  0.001
+                  0.00
                 </Text>
               </Text>
               <Text

--- a/packages/mobile/src/utils/formatting.ts
+++ b/packages/mobile/src/utils/formatting.ts
@@ -16,11 +16,13 @@ export const getMoneyDisplayValue = (
   // For stable currencies, if the value is lower than 0.01 we show an extra decimal point.
   // If the value is lower than 0.001, we just show <$0.001.
   const minValueToShow = Math.pow(10, -decimals - (currency === Currency.Celo ? 0 : 1))
-  if (value < minValueToShow) {
+  if (value > 0 && value < minValueToShow) {
     return `<${includeSymbol ? symbol : ''}${minValueToShow}`
   }
   const decimalsToUse =
-    currency === Currency.Celo || value >= Math.pow(10, -decimals) ? decimals : decimals + 1
+    currency === Currency.Celo || value <= 0 || value >= Math.pow(10, -decimals)
+      ? decimals
+      : decimals + 1
   const formattedValue = roundDown(value, decimalsToUse, roundingTolerance).toFormat(decimalsToUse)
   return includeSymbol ? symbol + formattedValue : formattedValue
 }


### PR DESCRIPTION
### Description

Fix for this issue: https://github.com/celo-org/wallet/issues/850

In short, if the user has exactly 0 balance, we now show 0.00 instead of <0.000.

The issue was introduced in this PR: https://github.com/celo-org/wallet/pull/659

### Other changes

N/A

### Tested

Manually

### How others should test

Create a new account. See that the balance shows up as exactly 0.

### Related issues

- Fixes #850

### Backwards compatibility

N/A