### PR TITLE
Make account number Tap to Copy link touchable

### DIFF
--- a/packages/mobile/src/components/AccountNumber.tsx
+++ b/packages/mobile/src/components/AccountNumber.tsx
@@ -1,5 +1,5 @@
 import colors from '@celo/react-components/styles/colors'
-import fontStyles from '@celo/react-components/styles/fonts'
+import fontStyles, { fontFamily } from '@celo/react-components/styles/fonts'
 import { getAddressChunks } from '@celo/utils/lib/address'
 import Clipboard from '@react-native-community/clipboard'
 import React from 'react'
@@ -52,6 +52,7 @@ export default function AccountNumber({ address, touchDisabled, location }: Prop
       testID="CopyAddressToClipboard"
     >
       <Text style={styles.text}>{addressString}</Text>
+      <Text style={styles.link}>{t('tapToCopy')}</Text>
     </TouchableOpacity>
   )
 }
@@ -66,10 +67,10 @@ const styles = StyleSheet.create({
     color: colors.gray4,
     marginVertical: 8,
   },
-  miniChunk: {
-    width: 23,
-  },
-  chunk: {
-    width: 40,
+  link: {
+    ...fontStyles.label,
+    textDecorationLine: 'underline',
+    color: colors.gray4,
+    fontFamily,
   },
 })

--- a/packages/mobile/src/components/__snapshots__/AccountNumber.test.tsx.snap
+++ b/packages/mobile/src/components/__snapshots__/AccountNumber.test.tsx.snap
@@ -50,5 +50,18 @@ exports[`AccountNumber renders correctly when touch enabled 1`] = `
   >
     0x 0000 0000 0000 0000 0000 0000 0000 0000 0000 7E57
   </Text>
+  <Text
+    style={
+      Object {
+        "color": "#9CA4A9",
+        "fontFamily": "Inter-Regular",
+        "fontSize": 13,
+        "lineHeight": 16,
+        "textDecorationLine": "underline",
+      }
+    }
+  >
+    tapToCopy
+  </Text>
 </View>
 `;

--- a/packages/mobile/src/fiatExchanges/ExternalExchanges.tsx
+++ b/packages/mobile/src/fiatExchanges/ExternalExchanges.tsx
@@ -1,6 +1,6 @@
 import ListItem from '@celo/react-components/components/ListItem'
 import colors from '@celo/react-components/styles/colors'
-import fontStyles, { fontFamily } from '@celo/react-components/styles/fonts'
+import fontStyles from '@celo/react-components/styles/fonts'
 import variables from '@celo/react-components/styles/variables'
 import { StackScreenProps } from '@react-navigation/stack'
 import React from 'react'
@@ -71,7 +71,6 @@ function ExternalExchanges({ route }: Props) {
         <View testID="accountBox" style={styles.accountBox}>
           <Text style={styles.accountLabel}>{t('sendFlow7:accountNumberLabel')}</Text>
           <AccountNumber address={account || ''} location={Screens.ExternalExchanges} />
-          <Text style={styles.link}>{t('accountScreen10:tapToCopy')}</Text>
         </View>
         <View style={styles.providersContainer}>
           {providers.map((provider, idx) => {
@@ -110,12 +109,6 @@ const styles = StyleSheet.create({
   accountLabel: {
     ...fontStyles.label,
     color: colors.gray5,
-  },
-  link: {
-    ...fontStyles.label,
-    textDecorationLine: 'underline',
-    color: colors.gray4,
-    fontFamily,
   },
   providerListItem: {
     flexDirection: 'row',

--- a/packages/mobile/src/navigator/DrawerNavigator.tsx
+++ b/packages/mobile/src/navigator/DrawerNavigator.tsx
@@ -1,6 +1,6 @@
 import PhoneNumberWithFlag from '@celo/react-components/components/PhoneNumberWithFlag'
 import colors from '@celo/react-components/styles/colors'
-import fontStyles, { fontFamily } from '@celo/react-components/styles/fonts'
+import fontStyles from '@celo/react-components/styles/fonts'
 import {
   createDrawerNavigator,
   DrawerContentComponentProps,
@@ -167,7 +167,6 @@ function CustomDrawerContent(props: DrawerContentComponentProps<DrawerContentOpt
       <View style={styles.drawerBottom}>
         <Text style={fontStyles.label}>{i18n.t('dappkit:address')}</Text>
         <AccountNumber address={account || ''} location={Screens.DrawerNavigator} />
-        <Text style={styles.link}>{i18n.t('accountScreen10:tapToCopy')}</Text>
         <Text style={styles.smallLabel}>{`Version ${appVersion}`}</Text>
       </View>
     </DrawerContentScrollView>
@@ -277,12 +276,6 @@ const styles = StyleSheet.create({
   smallLabel: {
     ...fontStyles.small,
     color: colors.gray4,
-  },
-  link: {
-    ...fontStyles.label,
-    textDecorationLine: 'underline',
-    color: colors.gray4,
-    fontFamily,
-    marginBottom: 32,
+    marginTop: 32,
   },
 })

--- a/packages/mobile/src/transactions/UserSection.tsx
+++ b/packages/mobile/src/transactions/UserSection.tsx
@@ -1,7 +1,7 @@
 import Expandable from '@celo/react-components/components/Expandable'
 import Touchable from '@celo/react-components/components/Touchable'
 import colors from '@celo/react-components/styles/colors'
-import fontStyles, { fontFamily } from '@celo/react-components/styles/fonts'
+import fontStyles from '@celo/react-components/styles/fonts'
 import { getDisplayNumberInternational } from '@celo/utils/lib/phoneNumbers'
 import React, { useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -76,7 +76,6 @@ export default function UserSection({
           <View style={styles.accountBox}>
             <Text style={styles.accountLabel}>{t('accountNumberLabel')}</Text>
             <AccountNumber address={address} location={Screens.TransactionReview} />
-            <Text style={styles.link}>{t('accountScreen10:tapToCopy')}</Text>
           </View>
         </View>
       )}
@@ -126,11 +125,5 @@ const styles = StyleSheet.create({
   accountLabel: {
     ...fontStyles.label,
     color: colors.gray5,
-  },
-  link: {
-    ...fontStyles.label,
-    textDecorationLine: 'underline',
-    color: colors.gray4,
-    fontFamily,
   },
 })


### PR DESCRIPTION
### Description

If `touchDisabled` is not true in the Account Number component, a touchable `Tap to Copy` link is automatically shown below the account number.

### Tested

![Screenshot_1625862494](https://user-images.githubusercontent.com/15326838/125133132-5f81de80-e0d3-11eb-8735-259d67ab69dc.png)
![Screenshot_1625862506](https://user-images.githubusercontent.com/15326838/125133133-601a7500-e0d3-11eb-88bf-2a0c83903811.png)
![Screenshot_1625862883](https://user-images.githubusercontent.com/15326838/125133263-98ba4e80-e0d3-11eb-8eed-2386c3237fbc.png)
