### PR TITLE
Fix clock sync

### DIFF
--- a/packages/mobile/src/utils/time.ts
+++ b/packages/mobile/src/utils/time.ts
@@ -12,6 +12,8 @@ import ntpClient from 'react-native-ntp-client'
 import i18n from 'src/i18n'
 import Logger from 'src/utils/Logger'
 
+const TAG = 'utils/time'
+
 // Source: https://github.com/webmania2014/angular-source1/blob/master/front/app/filters/tznames.js
 // Offsets reversed from original because moment returns with flipped sign
 const TIMEZONE_MAPPING: { [key: string]: string | any } = {
@@ -275,16 +277,19 @@ export const getDatetimeDisplayString = (timestamp: number, i18next: i18nType) =
 
 export const getRemoteTime = async () => {
   const getNetworkTime = promisify(ntpClient.getNetworkTime)
+  ntpClient.ntpReplyTimeout = 2000
+  const localTime = Date.now()
   try {
     const networkTime = await getNetworkTime('time.google.com', 123)
     return new Date(networkTime).getTime()
   } catch (error) {
+    Logger.error(TAG, 'failed first try', error)
     try {
       const networkTime = await getNetworkTime('time.cloudflare.com', 123)
       return new Date(networkTime).getTime()
     } catch (error) {
-      console.error('Error getting remote date: ', error)
-      return Date.now()
+      Logger.error(TAG, 'Error getting remote date', error)
+      return localTime
     }
   }
 }
@@ -296,7 +301,7 @@ export const clockInSync = async () => {
   const syncTime = await getRemoteTime()
   const drift = localTime - syncTime // in milliseconds
   Logger.info(
-    `clockInSync`,
+    `${TAG}/clockInSync`,
     `Local time: ${new Date(localTime).toLocaleString()} ` +
       `Remote time: ${new Date(syncTime).toLocaleString()} ` +
       `drift: ${drift} milliseconds`

--- a/packages/mobile/src/utils/time.ts
+++ b/packages/mobile/src/utils/time.ts
@@ -277,7 +277,6 @@ export const getDatetimeDisplayString = (timestamp: number, i18next: i18nType) =
 
 export const getRemoteTime = async () => {
   const getNetworkTime = promisify(ntpClient.getNetworkTime)
-  ntpClient.ntpReplyTimeout = 2000
   const localTime = Date.now()
   try {
     const networkTime = await getNetworkTime('time.google.com', 123)
@@ -294,7 +293,10 @@ export const getRemoteTime = async () => {
   }
 }
 
-export const DRIFT_THRESHOLD_IN_MS = 1000 * 4 // 4 seconds - Clique future block allowed time is 5 seconds
+// Old value was 4 seconds - Clique future block allowed time is 5 seconds
+// Switching to 21 seconds for now until we learn more about what specific services require
+// because each request can take up to 10 seconds to time out
+export const DRIFT_THRESHOLD_IN_MS = 1000 * 21
 
 export const clockInSync = async () => {
   const localTime = Date.now()

--- a/packages/mobile/src/utils/time.ts
+++ b/packages/mobile/src/utils/time.ts
@@ -293,10 +293,11 @@ export const getRemoteTime = async () => {
   }
 }
 
-// Old value was 4 seconds - Clique future block allowed time is 5 seconds
-// Switching to 21 seconds for now until we learn more about what specific services require
-// because each request can take up to 10 seconds to time out
-export const DRIFT_THRESHOLD_IN_MS = 1000 * 21
+// stokado requires accuracy within 5 mins
+// odis is getting rid of the timestamp but until then 60 seconds should work well
+// not sure if any other services need more accurate timing
+// but if not we can maybe remove this check altogether
+export const DRIFT_THRESHOLD_IN_MS = 1000 * 60
 
 export const clockInSync = async () => {
   const localTime = Date.now()


### PR DESCRIPTION
### Description

Looking at the logs provided in https://github.com/celo-org/wallet/issues/544 I noticed that when the clock sync check fails the drift is always 20 seconds. Then looking at the ntp library we are using here https://github.com/artem-russkikh/react-native-ntp-client/blob/master/lib/ntp-client.js it looks like the default timeout for the request is 10 seconds. Because we attempt 2 requests to 2 different ntp servers these add up to 20 seconds. Then the check fails because we want to be within 4 seconds. So if something is wrong with the network such as packet loss or udp port being blocked (which is pretty common on mobile devices) the check would always fail. Now it would be interesting to see what actually caused the timeout in this case.

The fix sets the ntp timeout to 2 seconds.

Of course there might be other issues causing this, such as the one we discussed where we don't account for the network delay roundtrip in the calculation.

Update: Looking at the history of this util function we used to use react-native-clock-sync which uses underneath react-native-ntp-client. The clock-sync lib keeps track of historical requests in order to estimate and adjust for network round trip delay. Using the ntp client directly does not do that as it is just a util that talks to ntp directly without any state.

### Other changes

I also modified the getRemoteTime function to return the initial start time in case of a timeout.

### Tested

In order to block the time servers we specify I modified the hosts file on my android emulator using the following steps roughly: block the time servers, then restart the app and notice after 10 seconds the clock sync screen shows up. There are probably other ways to test this but this is what I did locally using an android emulator:

Create a hosts file that looks something like:

`127.0.0.1       localhost`
`::1             ip6-localhost`
`172.0.0.1	time.google.com`
`172.0.0.1	time.cloudflare.com`
`

Now in order to push this file to the device we need to root the device.

> adb root
> adb disable-verity
> adb reboot
> adb root
> adb remount
> adb push hosts /etc/hosts

Now restart the app and wait 10 seconds to see the SetClock screen.

### How others should test

Start the app in various network conditions from really good wifi to bad signal mobile. Make sure the set clock screen does not show up after 5 seconds.

### Related issues

- Fixes #544 

### Backwards compatibility

Yes.
