### PR TITLE
chore: decodeURIComponent for WalletConnect deep links

### DIFF
--- a/packages/mobile/src/app/saga.test.ts
+++ b/packages/mobile/src/app/saga.test.ts
@@ -111,7 +111,7 @@ describe('App saga', () => {
       it(`handles ${name} connection links correctly`, async () => {
         await expectSaga(handleDeepLink, openDeepLink(link))
           .call(handleWalletConnectDeepLink, link)
-          .call(initialiseWalletConnect, connectionString)
+          .call(initialiseWalletConnect, decodeURIComponent(connectionString))
           .run()
       })
     }
@@ -128,7 +128,7 @@ describe('App saga', () => {
       it(`handles ${name} action links correctly`, async () => {
         await expectSaga(handleDeepLink, openDeepLink(link))
           .call(handleWalletConnectDeepLink, link)
-          .not.call(initialiseWalletConnect, connectionString)
+          .not.call(initialiseWalletConnect)
           .run()
       })
     }

--- a/packages/mobile/src/app/saga.test.ts
+++ b/packages/mobile/src/app/saga.test.ts
@@ -89,7 +89,9 @@ describe('App saga', () => {
   })
 
   describe('WalletConnect deeplinks', () => {
-    const connectionString = 'wc:1234@1?bridge=https://example.com&key=0x1234'
+    const connectionString = encodeURIComponent(
+      'wc:79a02f869d0f921e435a5e0643304548ebfa4a0430f9c66fe8b1a9254db7ef77@2?controller=false&publicKey=f661b0a9316a4ce0b6892bdce42bea0f45037f2c1bee9e118a3a4bc868a32a39&relay={"protocol":"waku"}'
+    )
     const connectionLinks = [
       {
         name: 'Android',

--- a/packages/mobile/src/walletConnect/walletConnect.ts
+++ b/packages/mobile/src/walletConnect/walletConnect.ts
@@ -26,7 +26,7 @@ export function* handleWalletConnectDeepLink(deepLink: string) {
 
   // connection request
   if (link.includes('?')) {
-    yield call(initialiseWalletConnect, link)
+    yield call(initialiseWalletConnect, decodeURIComponent(link))
   }
 
   // action request, we can do nothing

--- a/packages/mobile/src/walletConnect/walletConnect.ts
+++ b/packages/mobile/src/walletConnect/walletConnect.ts
@@ -24,9 +24,10 @@ export function* handleWalletConnectDeepLink(deepLink: string) {
     link = deepLink.substring(UNIVERSAL_LINK_PREFIX.length)
   }
 
+  link = decodeURIComponent(link)
   // connection request
   if (link.includes('?')) {
-    yield call(initialiseWalletConnect, decodeURIComponent(link))
+    yield call(initialiseWalletConnect, link)
   }
 
   // action request, we can do nothing
@@ -34,6 +35,6 @@ export function* handleWalletConnectDeepLink(deepLink: string) {
 
 export function isWalletConnectDeepLink(deepLink: string) {
   return [WC_PREFIX, DEEPLINK_PREFIX, UNIVERSAL_LINK_PREFIX].some((prefix) =>
-    deepLink.startsWith(prefix)
+    decodeURIComponent(deepLink).startsWith(prefix)
   )
 }


### PR DESCRIPTION
### Description

As a safe guard, decode URL encoded WalletConnect deep links.

### Other changes

N/A

### Tested

By opening these deep links.

### How others should test

https://use-contractkit.vercel.app or with the `scripts/run-in-memory-client.ts` script in the monorepo.

### Related issues

N/A

### Backwards compatibility

URI decoding is backwards compatible 👍