### PR TITLE
Allow selling CELO for cEUR even if user doesnt have a balance

### DIFF
--- a/packages/mobile/src/exchange/ExchangeScreenHeader.tsx
+++ b/packages/mobile/src/exchange/ExchangeScreenHeader.tsx
@@ -17,11 +17,11 @@ import { Currency, STABLE_CURRENCIES } from 'src/utils/currencies'
 
 interface Props {
   currency: Currency
-  makerToken: Currency | null
+  isCeloPurchase: boolean
   onChangeCurrency: (currency: Currency) => void
 }
 
-function ExchangeTradeScreenHeader({ currency, makerToken, onChangeCurrency }: Props) {
+function ExchangeTradeScreenHeader({ currency, isCeloPurchase, onChangeCurrency }: Props) {
   const [showingTokenPicker, setShowTokenPicker] = useState(false)
 
   const onCurrencySelected = (currency: Currency) => {
@@ -31,7 +31,6 @@ function ExchangeTradeScreenHeader({ currency, makerToken, onChangeCurrency }: P
 
   const closeCurrencyPicker = () => setShowTokenPicker(false)
 
-  const isCeloPurchase = makerToken !== Currency.Celo
   const balances = useSelector(balancesSelector)
   const exchangeRates = useSelector(localCurrencyExchangeRatesSelector)
 
@@ -43,9 +42,9 @@ function ExchangeTradeScreenHeader({ currency, makerToken, onChangeCurrency }: P
 
     let titleText
     let title
-    const singleTokenAvailable = currenciesWithBalance < 2
-    if (singleTokenAvailable) {
-      title = isCeloPurchase ? i18n.t('exchangeFlow9:buyGold') : i18n.t('exchangeFlow9:sellGold')
+    const tokenPickerEnabled = currenciesWithBalance >= 2 || !isCeloPurchase
+    if (!tokenPickerEnabled) {
+      title = i18n.t('exchangeFlow9:buyGold')
     } else {
       titleText = i18n.t('exchangeFlow9:tokenBalance', { token: currency })
       title = (
@@ -62,7 +61,7 @@ function ExchangeTradeScreenHeader({ currency, makerToken, onChangeCurrency }: P
     }
 
     return (
-      <Touchable disabled={singleTokenAvailable} onPress={showTokenPicker}>
+      <Touchable disabled={!tokenPickerEnabled} onPress={showTokenPicker}>
         <HeaderTitleWithBalance title={title} token={currency} switchTitleAndSubtitle={true} />
       </Touchable>
     )

--- a/packages/mobile/src/exchange/ExchangeTradeScreen.tsx
+++ b/packages/mobile/src/exchange/ExchangeTradeScreen.tsx
@@ -339,6 +339,7 @@ export class ExchangeTradeScreen extends React.Component<Props, State> {
   updateTransferCurrency = (currency: Currency) => this.setState({ transferCurrency: currency })
 
   render() {
+    const { buyCelo } = this.props.route.params
     const { t, exchangeRates } = this.props
     const { transferCurrency, exchangeRateInfoDialogVisible } = this.state
 
@@ -348,7 +349,7 @@ export class ExchangeTradeScreen extends React.Component<Props, State> {
       <SafeAreaView style={styles.container} edges={['bottom', 'top']}>
         <ExchangeTradeScreenHeader
           currency={transferCurrency}
-          makerToken={this.getMakerToken()}
+          isCeloPurchase={buyCelo}
           onChangeCurrency={this.updateTransferCurrency}
         />
         <DisconnectBanner />

--- a/packages/mobile/src/exchange/__snapshots__/ExchangeTradeScreen.test.tsx.snap
+++ b/packages/mobile/src/exchange/__snapshots__/ExchangeTradeScreen.test.tsx.snap
@@ -95,7 +95,7 @@ exports[`ExchangeTradeScreen renders correctly 1`] = `
     >
       <View
         accessible={true}
-        focusable={false}
+        focusable={true}
         nativeBackgroundAndroid={
           Object {
             "attribute": "selectableItemBackground",
@@ -141,7 +141,38 @@ exports[`ExchangeTradeScreen renders correctly 1`] = `
               }
             }
           >
-            exchangeFlow9:buyGold
+            <View
+              style={
+                Object {
+                  "flexDirection": "row",
+                }
+              }
+              testID="HeaderCurrencyPicker"
+            >
+              <Text
+                style={
+                  Object {
+                    "color": "#9CA4A9",
+                    "fontFamily": "Inter-Regular",
+                    "fontSize": 14,
+                    "lineHeight": 18,
+                  }
+                }
+              >
+                exchangeFlow9:tokenBalance
+              </Text>
+              <svg
+                fill="none"
+                height={16}
+                viewBox="0 0 16 16"
+                width={16}
+              >
+                <path
+                  d="M3 6l5 5 5-5"
+                  stroke="#B4B9BD"
+                />
+              </svg>
+            </View>
           </Text>
         </View>
       </View>


### PR DESCRIPTION
### Description

When a user doesn't have a cEUR balance, if they try to sell CELO they can now sell the CELO for cEUR as well.

### Other changes

The issue with the title not saying 'Sell CELO' is also fixed with this change.

### Tested

Manually

### How others should test

With an account that has no cEUR balance, go to the CELO tab and press `Sell`. See that you can tap on the header so that you sell CELO for cEUR.

### Related issues

- Fixes #872
- Fixes #865

### Backwards compatibility

N/A