### PR TITLE
Add CICO success event

### DIFF
--- a/packages/cloud-functions/package.json
+++ b/packages/cloud-functions/package.json
@@ -23,7 +23,7 @@
     "bignumber.js": "^9.0.0",
     "fast-json-stable-stringify": "~2.1.0",
     "firebase-admin": "^9.5.0",
-    "firebase-functions": "^3.6.0",
+    "firebase-functions": "^3.14.1",
     "i18next": "~19.0.2",
     "jsonwebtoken": "~8.5.1",
     "uuid": "^8.3.0"

--- a/packages/cloud-functions/src/cico/composeProviderUrl.ts
+++ b/packages/cloud-functions/src/cico/composeProviderUrl.ts
@@ -1,4 +1,5 @@
 import crypto from 'crypto'
+import { v4 as uuidv4 } from 'uuid'
 import {
   CASH_IN_SUCCESS_DEEPLINK,
   CASH_IN_SUCCESS_URL,
@@ -18,6 +19,7 @@ export const composeProviderUrl = (provider: Providers, requestData: ProviderReq
   const cashInSuccessDeepLink = `${CASH_IN_SUCCESS_DEEPLINK}/${provider}`
 
   if (provider === Providers.Moonpay) {
+    const txId = uuidv4()
     const unsignedUrl = `
       ${MOONPAY_DATA.widget_url}
         ?apiKey=${MOONPAY_DATA.public_key}
@@ -26,6 +28,7 @@ export const composeProviderUrl = (provider: Providers, requestData: ProviderReq
         &baseCurrencyCode=${fiatCurrency}
         &baseCurrencyAmount=${fiatAmount}
         &redirectURL=${encodeURIComponent(cashInSuccessDeepLink)}
+        &externalTransactionId=${txId}
         `.replace(findContinguousSpaces, '')
 
     const signature = crypto
@@ -80,6 +83,7 @@ export const composeProviderUrl = (provider: Providers, requestData: ProviderReq
         }
         &fiat=${fiatAmount}
         &redirectUrl=${cashInSuccessDeepLink}
+        &isWebView=true
       `.replace(findContinguousSpaces, '')
   }
 }

--- a/packages/mobile/ios/Podfile.lock
+++ b/packages/mobile/ios/Podfile.lock
@@ -409,7 +409,7 @@ PODS:
     - React
   - react-native-udp (2.6.1):
     - React
-  - react-native-webview (11.0.2):
+  - react-native-webview (11.6.5):
     - React-Core
   - React-RCTActionSheet (0.63.4):
     - React-Core/RCTActionSheetHeaders (= 0.63.4)
@@ -967,7 +967,7 @@ SPEC CHECKSUMS:
   react-native-splash-screen: 200d11d188e2e78cea3ad319964f6142b6384865
   react-native-tcp: e1a8c3ac010774cd71811989805ff3eaebb62f17
   react-native-udp: 54a1aa9bf5c0824f930b1ba6dbfb3fd3e733bba9
-  react-native-webview: dfd7202ff115c44d3ea401c2f36122fb3ac79f07
+  react-native-webview: 2e8fe70dc32b50d3231c23043f8e8b5a5525d346
   React-RCTActionSheet: 89a0ca9f4a06c1f93c26067af074ccdce0f40336
   React-RCTAnimation: 1bde3ecc0c104c55df246eda516e0deb03c4e49b
   React-RCTBlob: a97d378b527740cc667e03ebfa183a75231ab0f0

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -150,7 +150,7 @@
     "react-native-tcp": "https://github.com/celo-org/react-native-tcp#0b5948e",
     "react-native-udp": "git+https://github.com/celo-org/react-native-udp#730f295",
     "react-native-url-polyfill": "^1.2.0",
-    "react-native-webview": "^11.0.2",
+    "react-native-webview": "^11.6.4",
     "react-redux": "^7.2.0",
     "redux": "^4.0.5",
     "redux-persist": "^6.0.0",

--- a/packages/mobile/src/analytics/Properties.tsx
+++ b/packages/mobile/src/analytics/Properties.tsx
@@ -779,8 +779,7 @@ interface FiatExchangeEventsProperties {
     provider: string
   }
   [FiatExchangeEvents.cash_in_success]: {
-    provider: string
-    currency: string
+    provider: string | undefined
   }
   [FiatExchangeEvents.cico_add_funds_selected]: undefined
   [FiatExchangeEvents.cico_cash_out_selected]: undefined

--- a/packages/mobile/src/fiatExchanges/CashInSuccess.tsx
+++ b/packages/mobile/src/fiatExchanges/CashInSuccess.tsx
@@ -1,9 +1,11 @@
 import Button from '@celo/react-components/components/Button'
 import fontStyles from '@celo/react-components/styles/fonts'
 import { StackScreenProps } from '@react-navigation/stack'
-import React from 'react'
+import React, { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Image, StyleSheet, Text, View } from 'react-native'
+import { FiatExchangeEvents } from 'src/analytics/Events'
+import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import { Namespaces } from 'src/i18n'
 import { fiatExchange } from 'src/images/Images'
 import { noHeaderGestureDisabled } from 'src/navigator/Headers'
@@ -14,10 +16,24 @@ import { StackParamList } from 'src/navigator/types'
 type RouteProps = StackScreenProps<StackParamList, Screens.CashInSuccess>
 type Props = RouteProps
 
+const capitalizeProvider = (provider?: string) => {
+  if (provider) {
+    const providerArr = provider.split('')
+    providerArr[0].toUpperCase()
+    return providerArr.join('')
+  }
+}
+
 function CashInSuccessScreen({ route }: Props) {
   const { t } = useTranslation(Namespaces.fiatExchangeFlow)
 
   const { provider } = route.params
+
+  useEffect(() => {
+    ValoraAnalytics.track(FiatExchangeEvents.cash_in_success, {
+      provider,
+    })
+  }, [])
 
   return (
     <View style={styles.container}>
@@ -26,7 +42,7 @@ function CashInSuccessScreen({ route }: Props) {
         <Text style={styles.title}>{t('cicoSuccess.title')}</Text>
         <Text style={styles.contentText}>
           {provider
-            ? t('cicoSuccess.bodyWithProvider', { provider })
+            ? t('cicoSuccess.bodyWithProvider', { provider: capitalizeProvider(provider) })
             : t('cicoSuccess.bodyWithoutProvider')}
         </Text>
       </View>

--- a/packages/mobile/src/fiatExchanges/saga.ts
+++ b/packages/mobile/src/fiatExchanges/saga.ts
@@ -139,7 +139,6 @@ export function* searchNewItemsForProviderTxs({ transactions }: NewTransactionsI
       if (providerAddresses.includes(tx.address)) {
         ValoraAnalytics.track(FiatExchangeEvents.cash_in_success, {
           provider: lastUsedProvider?.name ?? 'unknown',
-          currency: tx.amount.currencyCode,
         })
         yield put(assignProviderToTxHash(tx.hash, tx.amount.currencyCode))
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5530,6 +5530,15 @@
     "@types/qs" "*"
     "@types/serve-static" "*"
 
+"@types/express@4.17.3":
+  version "4.17.3"
+  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.3.tgz#38e4458ce2067873b09a73908df488870c303bd9"
+  integrity sha512-I8cGRJj3pyOLs/HndoP+25vOqhqWkAZsWMEmq1qXy/b/M3ppufecUwaK2/TVDVxcV61/iSdhykUjQQ2DLSrTdg==
+  dependencies:
+    "@types/body-parser" "*"
+    "@types/express-serve-static-core" "*"
+    "@types/serve-static" "*"
+
 "@types/express@4.17.4":
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.4.tgz#e78bf09f3f530889575f4da8a94cd45384520aac"
@@ -13520,6 +13529,16 @@ firebase-functions-test@^0.2.0:
   dependencies:
     "@types/lodash" "^4.14.104"
     lodash "^4.17.5"
+
+firebase-functions@^3.14.1:
+  version "3.14.1"
+  resolved "https://registry.yarnpkg.com/firebase-functions/-/firebase-functions-3.14.1.tgz#3ac5bc70989365874f41d06bca3b42a233dd6039"
+  integrity sha512-hL/qm+i5i1qKYmAFMlQ4mwRngDkP+3YT3F4E4Nd5Hj2QKeawBdZiMGgEt6zqTx08Zq04vHiSnSM0z75UJRSg6Q==
+  dependencies:
+    "@types/express" "4.17.3"
+    cors "^2.8.5"
+    express "^4.17.1"
+    lodash "^4.17.14"
 
 firebase-functions@^3.6.0:
   version "3.6.0"
@@ -22784,10 +22803,10 @@ react-native-version@^3.1.0:
     resolve-from "^5.0.0"
     semver "^6.0.0"
 
-react-native-webview@^11.0.2:
-  version "11.0.2"
-  resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-11.0.2.tgz#c88e84fa470f04ff070ff8a2c7f4d7295d46bb06"
-  integrity sha512-GDyIBRbCZ2wbMUGCxA7LufSEbSoWKOzkFB8YljmAffA15tzN6ccvGEquB/hkk5KhvoYy300kwJyEmyBeG6d/AA==
+react-native-webview@^11.6.4:
+  version "11.6.5"
+  resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-11.6.5.tgz#34e86a342c6a2cbcf109db98f639f7bb8f055da2"
+  integrity sha512-5U+hI8snkCrFeDy+bUTszwhzcJIenaaOy3ubhY77HZq7R0pFIZzRYWkT0YXe1ymRYW9mSU96nr6S0AVDk8qkMw==
   dependencies:
     escape-string-regexp "2.0.0"
     invariant "2.2.4"


### PR DESCRIPTION
### Description
Add a `cash_in_success` analytics event to the CICO success screen. Also addressed a bug where the provider name was not being capitalized.

### Other changes
- Updated the `webview` and `firebase functions` packages
- Added to the Xanpool url to specify that it's being displaying in a webview
- Added an `externalTransactionId` to the Moonpay url to allow for higher data fidelity

### Tested
Manually

### How others should test
N/A

### Related issues
- Fixes #888

### Backwards compatibility
Yes