### PR TITLE
Remove VSCode configs for packages no longer in the repo

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,54 +2,6 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "Debug PhoneNumberPrivacy Combiner Tests",
-      "type": "node",
-      "request": "launch",
-      "runtimeArgs": [
-        "--inspect-brk",
-        "${workspaceRoot}/node_modules/.bin/jest",
-        "--rootDir",
-        "${workspaceFolder}/packages/phone-number-privacy",
-        "--runInBand",
-        "${workspaceFolder}/packages/phone-number-privacy/combiner/test/**",
-      ],
-      "console": "integratedTerminal",
-      "internalConsoleOptions": "neverOpen",
-      "port": 9229
-    },
-    {
-      "name": "Debug PhoneNumberPrivacy Signer Tests",
-      "type": "node",
-      "request": "launch",
-      "runtimeArgs": [
-        "--inspect-brk",
-        "${workspaceRoot}/node_modules/.bin/jest",
-        "--rootDir",
-        "${workspaceFolder}/packages/phone-number-privacy/signer",
-        "--runInBand",
-        "${workspaceFolder}/packages/phone-number-privacy/signer/test/**",
-      ],
-      "console": "integratedTerminal",
-      "internalConsoleOptions": "neverOpen",
-      "port": 9229
-    },
-    {
-      "name": "Debug ContractKit Tests",
-      "type": "node",
-      "request": "launch",
-      "runtimeArgs": [
-        "--inspect-brk",
-        "${workspaceRoot}/node_modules/.bin/jest",
-        "--rootDir",
-        "${workspaceFolder}/packages/contractkit",
-        "--runInBand",
-        "${workspaceFolder}/packages/contractkit/src/**/*.test.ts",
-      ],
-      "console": "integratedTerminal",
-      "internalConsoleOptions": "neverOpen",
-      "port": 9229
-    },
-    {
       "name": "Debug Komencikit Tests",
       "type": "node",
       "request": "launch",


### PR DESCRIPTION
### Description

Remove VSCode configs for packages no longer in the repo.

### Other changes

No.

### Tested

N/A.


### How others should test

N/A.

### Related issues

N/A.

### Backwards compatibility

N/A.