### PR TITLE
Add mobile check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           path: test-results
   mobile:
-    name: Mobile Tests
+    name: Mobile
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,4 +26,25 @@ jobs:
       - name: 'Upload Test Results'
         uses: actions/upload-artifact@v2
         with:
-          path: test-results
+          path: test-results  mobile-tests:
+  mobile:
+    name: Mobile Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '12'
+          check-latest: true
+      - name: Install Yarn dependencies
+        run: yarn
+      - name: Build Yarn packages
+        run: yarn build --ignore docs
+      - name: Run mobile tests
+        run: |
+          mkdir -p test-results/jest
+          yarn --cwd packages/mobile test:ci
+      - name: Upload Coverage Report
+        uses: actions/upload-artifact@v2
+        with:
+          path: packages/mobile/coverage/lcov-report

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
       - name: 'Upload Test Results'
         uses: actions/upload-artifact@v2
         with:
-          path: test-results  mobile-tests:
+          path: test-results
   mobile:
     name: Mobile Tests
     runs-on: ubuntu-latest

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -22,7 +22,7 @@
     "dev:emulator:run": "$ANDROID_HOME/emulator/emulator -avd",
     "test": "export TZ=UTC && ./scripts/sync_branding.sh -b celo && jest --silent",
     "test:all": "yarn lint && yarn build:ts && yarn test",
-    "test:ci": "yarn test --coverage",
+    "test:ci": "yarn test --coverage --clearCache",
     "test:watch": "yarn test --watch --maxWorkers=4",
     "test:verbose": "export TZ=UTC && jest --verbose",
     "test:e2e:android": "./scripts/run_e2e.sh -p android -r",


### PR DESCRIPTION
### Description

This PR implements the mobile tests check from CircleCI to GitHub Actions. Later PR will implement caching and other optimizations. Mobile tests from Circle has also been broken into two actions, one for mobile tests and one for vulnerability check.

### Tested

This is replacing the CircleCI config. As long as it does the same thing and passes it doesn't need to be tested further.

### How others should test

No testing needed, just need to verify it passes.

### Related issues

- Implements #521.
- Replaces #518.

### Backwards compatibility

GitHub Actions will be replacing CircleCI.